### PR TITLE
core: add sleep_abortable instantiation for manual_clock

### DIFF
--- a/include/seastar/core/sleep.hh
+++ b/include/seastar/core/sleep.hh
@@ -28,6 +28,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/timer.hh>
 
 namespace seastar {
@@ -89,5 +90,6 @@ future<> sleep_abortable(typename Clock::duration dur, abort_source& as);
 
 extern template future<> sleep_abortable<steady_clock_type>(typename steady_clock_type::duration, abort_source&);
 extern template future<> sleep_abortable<lowres_clock>(typename lowres_clock::duration, abort_source&);
+extern template future<> sleep_abortable<manual_clock>(typename manual_clock::duration, abort_source&);
 
 }

--- a/src/core/future-util.cc
+++ b/src/core/future-util.cc
@@ -124,5 +124,6 @@ future<> sleep_abortable(typename Clock::duration dur, abort_source& as) {
 
 template future<> sleep_abortable<steady_clock_type>(typename steady_clock_type::duration, abort_source&);
 template future<> sleep_abortable<lowres_clock>(typename lowres_clock::duration, abort_source&);
+template future<> sleep_abortable<manual_clock>(typename manual_clock::duration, abort_source&);
 
 }

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -78,6 +78,20 @@ SEASTAR_TEST_CASE(test_sleep_abortable) {
     return f.finally([as = std::move(as)] { });
 }
 
+SEASTAR_TEST_CASE(test_sleep_abortable_no_abort) {
+    auto as = std::make_unique<abort_source>();
+
+    // Check that the sleep completes as usual if the
+    // abort source doesn't fire.
+    auto f = sleep_abortable<manual_clock>(100s, *as);
+    manual_clock::advance(99s);
+    BOOST_REQUIRE(!f.available());
+    manual_clock::advance(101s);
+    return f.finally([as = std::move(as)] { });
+}
+
+
+
 // Verify that negative sleep does not sleep forever. It should not sleep
 // at all.
 SEASTAR_TEST_CASE(test_negative_sleep_abortable) {


### PR DESCRIPTION
This is useful for unit testing classes which use
sleep_abortable: all the types work, we just
weren't creating the symbol in the .cc file.

Signed-off-by: John Spray <jcs@redpanda.com>