### PR TITLE
loop: Improve concepts to match requirements

### DIFF
--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -472,7 +472,8 @@ future<> do_for_each(Iterator begin, Iterator end, AsyncAction action) noexcept 
 ///         \c action failed.
 template<typename Container, typename AsyncAction>
 SEASTAR_CONCEPT( requires requires (Container c, AsyncAction aa) {
-    { futurize_invoke(aa, *c.begin()) } -> std::same_as<future<>>;
+    { futurize_invoke(aa, *std::begin(c)) } -> std::same_as<future<>>;
+    std::end(c);
 } )
 inline
 future<> do_for_each(Container& c, AsyncAction action) noexcept {
@@ -602,7 +603,10 @@ parallel_for_each_impl(Range&& range, Func&& func) {
 } // namespace internal
 
 template <typename Range, typename Func>
-SEASTAR_CONCEPT( requires requires (Func f, Range r) { { f(*r.begin()) } -> std::same_as<future<>>; } )
+SEASTAR_CONCEPT( requires requires (Func f, Range r) {
+    { f(*std::begin(r)) } -> std::same_as<future<>>;
+    std::end(r);
+} )
 inline
 future<>
 parallel_for_each(Range&& range, Func&& func) noexcept {
@@ -703,7 +707,10 @@ max_concurrent_for_each(Iterator begin, Iterator end, size_t max_concurrent, Fun
 ///         complete.  If one or more return an exception, the return value
 ///         contains one of the exceptions.
 template <typename Range, typename Func>
-SEASTAR_CONCEPT( requires std::ranges::range<Range> && requires (Func f, Range r) { { f(*r.begin()) } -> std::same_as<future<>>; } )
+SEASTAR_CONCEPT( requires requires (Func f, Range r) {
+    { f(*std::begin(r)) } -> std::same_as<future<>>;
+    std::end(r);
+} )
 inline
 future<>
 max_concurrent_for_each(Range&& range, size_t max_concurrent, Func&& func) noexcept {


### PR DESCRIPTION
**NOTE**: This is mostly needed for clang-13 and isn't urgent.

Improve the concept checks for range versions of do_for_each,
parallel_for_each and max_concurrent_for_each to match the
requirements that the implementation requires.

The code now compiles with clang-13/libc++ and doesn't
implicitly depend on the <ranges> header.

Signed-off-by: Ben Pope <ben@vectorized.io>
Message-Id: <20211221042345.1299645-1-ben@vectorized.io>
(cherry picked from commit 43bdb1b59773560309474a2f3ec7552254055e09)

Upstream: https://github.com/scylladb/seastar/commit/43bdb1b59773560309474a2f3ec7552254055e09