### PR TITLE
Add DN name to accept_result struct

### DIFF
--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -270,10 +270,17 @@ public:
 /// \addtogroup networking-module
 /// @{
 
+/// Distinguished name
+struct session_dn {
+    sstring subject;
+    sstring issuer;
+};
+
 /// The result of an server_socket::accept() call
 struct accept_result {
     connected_socket connection;  ///< The newly-accepted connection
     socket_address remote_address;  ///< The address of the peer that connected to us
+    std::optional<session_dn> dn;  ///< Distinguished name
 };
 
 /// A listening socket, waiting to accept incoming network connections.


### PR DESCRIPTION
Previously, it was possible to get DN using dn_callback passed to
credentials object. This callback is invoked on every handshake (if
'client_auth' is set to true) and accepts two parameters, subject and
issuer. But there is no way for the user of the tls library to connect
particular client connection with the DN string. Also, it's not the best
way to obtain the DN string because the handshake is delayed until the
first read or write attempt is made.

This commit solves the issue by
- adding a DN field to the accept_result struct
- propagating DN name to the accept_result
- forcing TLS handshake after the connection is established and before
  the accept_result is returned in order to get DN field populated

In order for this mechanism to work the user must use 'seastar::tls::listen'
method directly and not 'wrap_server'. Also, the user have to pass
the credentials with client-auth set to 'REQUIRED' to the 'listen'
function.