### PR TITLE
Allow multiple internal metrics implementations

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -360,9 +360,9 @@ public:
     virtual ~metric_groups_def() = default;
     metric_groups_def(const metric_groups_def&) = delete;
     metric_groups_def(metric_groups_def&&) = default;
-    virtual metric_groups_def& add_metric(group_name_type name, const metric_definition& md) = 0;
-    virtual metric_groups_def& add_group(group_name_type name, const std::initializer_list<metric_definition>& l) = 0;
-    virtual metric_groups_def& add_group(group_name_type name, const std::vector<metric_definition>& l) = 0;
+    virtual metric_groups_def& add_metric(group_name_type name, const metric_definition& md, int handle) = 0;
+    virtual metric_groups_def& add_group(group_name_type name, const std::initializer_list<metric_definition>& l, int handle) = 0;
+    virtual metric_groups_def& add_group(group_name_type name, const std::vector<metric_definition>& l, int handle) = 0;
 };
 
 instance_id_type shard();

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -176,9 +176,9 @@ public:
     ~metric_groups_impl();
     metric_groups_impl(const metric_groups_impl&) = delete;
     metric_groups_impl(metric_groups_impl&&) = default;
-    metric_groups_impl& add_metric(group_name_type name, const metric_definition& md);
-    metric_groups_impl& add_group(group_name_type name, const std::initializer_list<metric_definition>& l);
-    metric_groups_impl& add_group(group_name_type name, const std::vector<metric_definition>& l);
+    metric_groups_impl& add_metric(group_name_type name, const metric_definition& md, int handle = default_handle());
+    metric_groups_impl& add_group(group_name_type name, const std::initializer_list<metric_definition>& l, int handle = default_handle());
+    metric_groups_impl& add_group(group_name_type name, const std::vector<metric_definition>& l, int handle = default_handle());
 };
 
 class impl;
@@ -387,7 +387,7 @@ std::unique_ptr<metric_groups_def> create_metric_groups();
 /*!
  * \brief set the metrics configuration
  */
-future<> configure(const boost::program_options::variables_map & opts);
+future<> configure(const boost::program_options::variables_map & opts, int handle = impl::default_handle());
 
 /*!
  * \brief get the metrics configuration desciprtion

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -37,6 +37,9 @@ namespace metrics {
 namespace impl {
 
 using labels_type = std::map<sstring, sstring>;
+
+int default_handle();
+
 }
 }
 }
@@ -179,6 +182,8 @@ public:
 };
 
 class impl;
+using metric_implementations = std::vector<::seastar::shared_ptr<impl>>;
+metric_implementations& get_metric_implementations();
 
 class registered_metric {
     metric_info _info;
@@ -316,12 +321,15 @@ struct config {
 };
 
 class impl {
+    int _handle;
     value_map _value_map;
     config _config;
     bool _dirty = true;
     shared_ptr<metric_metadata> _metadata;
     std::vector<std::vector<metric_function>> _current_metrics;
 public:
+    explicit impl(int handle) : _handle(handle) {}
+
     value_map& get_value_map() {
         return _value_map;
     }
@@ -342,6 +350,10 @@ public:
         _config = c;
     }
 
+    int get_handle() const {
+        return _handle;
+    }
+
     shared_ptr<metric_metadata> metadata();
 
     std::vector<std::vector<metric_function>>& functions();
@@ -358,7 +370,7 @@ using values_reference = shared_ptr<values_copy>;
 
 foreign_ptr<values_reference> get_values();
 
-shared_ptr<impl> get_local_impl();
+shared_ptr<impl> get_local_impl(int handle = default_handle());
 
 void unregister_metric(const metric_id & id);
 

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -190,7 +190,7 @@ class registered_metric {
     metric_function _f;
     shared_ptr<impl> _impl;
 public:
-    registered_metric(metric_id id, metric_function f, bool enabled=true);
+    registered_metric(metric_id id, metric_function f, bool enabled=true, int handle=default_handle());
     virtual ~registered_metric() {}
     virtual metric_value operator()() const {
         return _f();
@@ -365,14 +365,15 @@ public:
     }
 };
 
-const value_map& get_value_map();
+const value_map& get_value_map(int handle = default_handle());
 using values_reference = shared_ptr<values_copy>;
 
-foreign_ptr<values_reference> get_values();
+foreign_ptr<values_reference> get_values(int handle = default_handle());
 
 shared_ptr<impl> get_local_impl(int handle = default_handle());
 
-void unregister_metric(const metric_id & id);
+
+void unregister_metric(const metric_id & id, int handle = default_handle());
 
 /*!
  * \brief initialize metric group

--- a/include/seastar/core/metrics_registration.hh
+++ b/include/seastar/core/metrics_registration.hh
@@ -51,6 +51,7 @@ namespace seastar {
 namespace metrics {
 
 namespace impl {
+int default_handle();
 class metric_groups_def;
 struct metric_definition_impl;
 class metric_groups_impl;
@@ -98,7 +99,7 @@ public:
      *
      * combine the constructor with the add_group functionality.
      */
-    metric_groups(std::initializer_list<metric_group_definition> mg);
+    metric_groups(std::initializer_list<metric_group_definition> mg, int handle = impl::default_handle());
 
     /*!
      * \brief Add metrics belonging to the same group.
@@ -120,7 +121,7 @@ public:
      * has no copy constructor, so the other overload (with vector) cannot be
      * invoked on a braced-init-list.
      */
-    metric_groups& add_group(const group_name_type& name, const std::initializer_list<metric_definition>& l);
+    metric_groups& add_group(const group_name_type& name, const std::initializer_list<metric_definition>& l, int handle = impl::default_handle());
 
     /*!
      * \brief Add metrics belonging to the same group.
@@ -138,7 +139,7 @@ public:
      * You can chain add_group calls like:
      * _metrics.add_group("my group1", vec1).add_group("my group2", vec2);
      */
-    metric_groups& add_group(const group_name_type& name, const std::vector<metric_definition>& l);
+    metric_groups& add_group(const group_name_type& name, const std::vector<metric_definition>& l, int handle = impl::default_handle());
 
     /*!
      * \brief clear all metrics groups registrations.
@@ -165,7 +166,7 @@ public:
      *
      *
      */
-    metric_group(const group_name_type& name, std::initializer_list<metric_definition> l);
+    metric_group(const group_name_type& name, std::initializer_list<metric_definition> l, int handle = impl::default_handle());
 };
 
 

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -37,15 +37,16 @@ struct config {
     sstring hostname; //!< hostname is deprecated, use label instead
     std::optional<metrics::label_instance> label; //!< A label that will be added to all metrics, we advice not to use it and set it on the prometheus server
     sstring prefix = "seastar"; //!< a prefix that will be added to metric names
+    int handle = metrics::impl::default_handle(); //!< Handle that specifies which metric implementation to query
 };
 
 future<> start(httpd::http_server_control& http_server, config ctx);
 
-/// \defgroup add_prometheus_routes adds a /metrics endpoint that returns prometheus metrics
+/// \defgroup add_prometheus_routes adds a specfied endpoint (defualts to /metrics) that returns prometheus metrics
 ///    in txt format
 /// @{
-future<> add_prometheus_routes(distributed<http_server>& server, config ctx);
-future<> add_prometheus_routes(http_server& server, config ctx);
+future<> add_prometheus_routes(distributed<http_server>& server, config ctx, sstring route = "/metrics");
+future<> add_prometheus_routes(http_server& server, config ctx, sstring route = "/metrics");
 /// @}
 }
 }

--- a/include/seastar/core/scollectd.hh
+++ b/include/seastar/core/scollectd.hh
@@ -348,7 +348,7 @@ private:
 
 extern const plugin_instance_id per_cpu_plugin_instance;
 
-void configure(const boost::program_options::variables_map&);
+void configure(const boost::program_options::variables_map&, int handle = seastar::metrics::impl::default_handle());
 boost::program_options::options_description get_options_description();
 void remove_polled_metric(const type_instance_id &);
 
@@ -368,8 +368,8 @@ class plugin_instance_metrics;
  */
 struct registration {
     registration() = default;
-    registration(const type_instance_id& id);
-    registration(type_instance_id&& id);
+    registration(const type_instance_id& id, int handle = seastar::metrics::impl::default_handle());
+    registration(type_instance_id&& id, int handle = seastar::metrics::impl::default_handle());
     registration(const registration&) = delete;
     registration(registration&&) = default;
     ~registration();
@@ -782,8 +782,8 @@ seastar::metrics::impl::metric_id to_metrics_id(const type_instance_id & id);
  */
 template<typename Arg>
 [[deprecated("Use the metrics layer")]] static type_instance_id add_polled_metric(const type_instance_id & id, description d,
-        Arg&& arg, bool enabled = true) {
-    seastar::metrics::impl::get_local_impl()->add_registration(to_metrics_id(id), arg.type, seastar::metrics::impl::make_function(arg.value, arg.type), d, enabled);
+        Arg&& arg, bool enabled = true, int handle = seastar::metrics::impl::default_handle()) {
+    seastar::metrics::impl::get_local_impl(handle)->add_registration(to_metrics_id(id), arg.type, seastar::metrics::impl::make_function(arg.value, arg.type), d, enabled);
     return id;
 }
 /*!

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -121,8 +121,8 @@ bool label_instance::operator!=(const label_instance& id2) const {
 label shard_label("shard");
 namespace impl {
 
-registered_metric::registered_metric(metric_id id, metric_function f, bool enabled) :
-        _f(f), _impl(get_local_impl()) {
+registered_metric::registered_metric(metric_id id, metric_function f, bool enabled, int handle) :
+        _f(f), _impl(get_local_impl(handle)) {
     _info.enabled = enabled;
     _info.id = id;
 }
@@ -262,20 +262,20 @@ void impl::remove_registration(const metric_id& id) {
     }
 }
 
-void unregister_metric(const metric_id & id) {
-    get_local_impl()->remove_registration(id);
+void unregister_metric(const metric_id & id, int handle) {
+    get_local_impl(handle)->remove_registration(id);
 }
 
-const value_map& get_value_map() {
-    return get_local_impl()->get_value_map();
+const value_map& get_value_map(int handle) {
+    return get_local_impl(handle)->get_value_map();
 }
 
-foreign_ptr<values_reference> get_values() {
+foreign_ptr<values_reference> get_values(int handle) {
     shared_ptr<values_copy> res_ref = ::seastar::make_shared<values_copy>();
     auto& res = *(res_ref.get());
     auto& mv = res.values;
-    res.metadata = get_local_impl()->metadata();
-    auto & functions = get_local_impl()->functions();
+    res.metadata = get_local_impl(handle)->metadata();
+    auto & functions = get_local_impl(handle)->functions();
     mv.reserve(functions.size());
     for (auto&& i : functions) {
         value_vector values;

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -219,11 +219,11 @@ public:
     /** @} */
 };
 
-static future<> get_map_value(metrics_families_per_shard& vec) {
+static future<> get_map_value(metrics_families_per_shard& vec, int handle) {
     vec.resize(smp::count);
-    return parallel_for_each(boost::irange(0u, smp::count), [&vec] (auto cpu) {
-        return smp::submit_to(cpu, [] {
-            return mi::get_values();
+    return parallel_for_each(boost::irange(0u, smp::count), [handle, &vec] (auto cpu) {
+        return smp::submit_to(cpu, [handle] {
+            return mi::get_values(handle);
         }).then([&vec, cpu] (auto res) {
             vec[cpu] = std::move(res);
         });
@@ -580,7 +580,7 @@ public:
         rep->write_body("txt", [this, metric_family_name, prefix] (output_stream<char>&& s) {
             return do_with(metrics_families_per_shard(), output_stream<char>(std::move(s)),
                     [this, prefix, &metric_family_name] (metrics_families_per_shard& families, output_stream<char>& s) mutable {
-                return get_map_value(families).then([&s, &families, this, prefix, &metric_family_name]() mutable {
+                return get_map_value(families, _ctx.handle).then([&s, &families, this, prefix, &metric_family_name]() mutable {
                     return do_with(get_range(families, metric_family_name, prefix),
                             [&s, this](metric_family_range& m) {
                         return write_text_representation(s, _ctx, m);
@@ -596,14 +596,14 @@ public:
 
 
 
-future<> add_prometheus_routes(http_server& server, config ctx) {
-    server._routes.put(GET, "/metrics", new metrics_handler(ctx));
+future<> add_prometheus_routes(http_server& server, config ctx, sstring route) {
+    server._routes.put(GET, route, new metrics_handler(ctx));
     return make_ready_future<>();
 }
 
-future<> add_prometheus_routes(distributed<http_server>& server, config ctx) {
-    return server.invoke_on_all([ctx](http_server& s) {
-        return add_prometheus_routes(s, ctx);
+future<> add_prometheus_routes(distributed<http_server>& server, config ctx, sstring route) {
+    return server.invoke_on_all([ctx, route](http_server& s) {
+        return add_prometheus_routes(s, ctx, route);
     });
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3581,6 +3581,12 @@ smp::get_options_description()
     return opts;
 }
 
+thread_local metrics::impl::metric_implementations metric_impls;
+
+metrics::impl::metric_implementations& metrics::impl::get_metric_implementations() {
+    return metric_impls;
+}
+
 thread_local scollectd::impl scollectd_impl;
 
 scollectd::impl & scollectd::get_impl() {

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -76,12 +76,12 @@ registration::~registration() {
     unregister();
 }
 
-registration::registration(const type_instance_id& id)
-: _id(id), _impl(seastar::metrics::impl::get_local_impl()) {
+registration::registration(const type_instance_id& id, int handle)
+: _id(id), _impl(seastar::metrics::impl::get_local_impl(handle)) {
 }
 
-registration::registration(type_instance_id&& id)
-: _id(std::move(id)), _impl(seastar::metrics::impl::get_local_impl()) {
+registration::registration(type_instance_id&& id, int handle)
+: _id(std::move(id)), _impl(seastar::metrics::impl::get_local_impl(handle)) {
 }
 
 seastar::metrics::impl::metric_id to_metrics_id(const type_instance_id & id) {
@@ -527,7 +527,7 @@ future<> send_metric(const type_instance_id & id,
     return get_impl().send_metric(id, values);
 }
 
-void configure(const boost::program_options::variables_map & opts) {
+void configure(const boost::program_options::variables_map & opts, int handle) {
     bool enable = opts["collectd"].as<bool>();
     if (!enable) {
         return;
@@ -536,7 +536,7 @@ void configure(const boost::program_options::variables_map & opts) {
     auto period = std::chrono::milliseconds(opts["collectd-poll-period"].as<unsigned>());
 
     auto host = (opts["collectd-hostname"].as<std::string>() == "")
-            ? seastar::metrics::impl::get_local_impl()->get_config().hostname
+            ? seastar::metrics::impl::get_local_impl(handle)->get_config().hostname
             : sstring(opts["collectd-hostname"].as<std::string>());
 
     // Now create send loops on each cpu


### PR DESCRIPTION
Previously, seastar collected all metrics (and metrics related metadata) in a single object (`metrics::impl::impl`). The consequence of this is that there was no way to have multiple metrics namespaces and expose each namespace through its own prometheus endpoint. If an application published a large volume of metrics, the user had to filter them by using by using the `name` request parameter of the prometheus endpoint. The downside of this approach is that the user must have knowledge of the metrics set and, even in that case,  some queries cannot be expressed in terms of substring matching (i.e. the existing filtering implementation).

A more flexible approach is to allow applications to categorise metrics at the time of registering them and expose the different metrics set on different prometheus endpoints if required. This is the approach taken for this PR. The metrics registration api
now allows applications to specify the internal metrics implementation (think of it as a metrics bucket) via an integer handle. Internally, whenever a shard needs to handle a metric related operation for a handle it hasn't seen before, a new `metrics::impl::impl` object is created on the fly. This leads to a simple api, as applications don't need to pre-register metric implementation before adding groups.

Here is an example of how to add metric groups to a specific "bucket" and expose each "bucket" on a prometheus endpoint.
Metrics in the `foo` group will be exposed on the default `metric` prometheus endpoint, while the `baz` group will be exposed
on the `extra_metrics` endpoint.
```
auto extra_metrics_handle = 100;

ss::metrics::metric_groups metrics
metrics.add_group(
  "foo", {sm::make_gauge("bar", [] { return 1; }, sm::description("foobar metric")}); 
metrics.add_group(
  "baz", {sm::make_gauge("daz", [] { return 1; }, sm::description("bazdaz metric")}, extra_metrics_handle);

...
ss::prometheus::config default;
default.prefix = "default metrics bucket";

ss::prometheus::config extra;
extra.prefix = "extra metrics bucket";
extra.handle = extra_metrics_handle;

seastar::prometheus::add_prometheus_routes(your_server, default).get();
seastar::prometheus::add_prometheus_routes(your_server, extra, "/extra_metrics").get();
```