### PR TITLE
Sentinel handling fixes for seastar-addr2line.

### DIFF
--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -19,11 +19,8 @@
 # Copyright (C) 2017 ScyllaDB
 
 import argparse
-import collections
 import re
 import sys
-import subprocess
-from enum import Enum
 
 from addr2line import BacktraceResolver
 

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -205,14 +205,14 @@ if args.test:
         ('kernel callstack: ', None),
         ('kernel callstack: 0xffffffffffffff80',
             {
-                'type': BacktraceResolver.BacktraceParser.Type.KERNEL_ADDRESS,
+                'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
                 'prefix': 'kernel callstack: ',
                 'addresses': [{'path': '<kernel>', 'addr': '0xffffffffffffff80'}]
             }
         ),
         ('kernel callstack: 0xffffffffffffff80 0xffffffffaf15ccca',
             {
-                'type': BacktraceResolver.BacktraceParser.Type.KERNEL_ADDRESS,
+                'type': BacktraceResolver.BacktraceParser.Type.ADDRESS,
                 'prefix': 'kernel callstack: ',
                 'addresses': [{'path': '<kernel>', 'addr': '0xffffffffffffff80'}, {'path': '<kernel>', 'addr': '0xffffffffaf15ccca'}]
             }

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -22,7 +22,7 @@ import argparse
 import re
 import sys
 
-from addr2line import BacktraceResolver
+from addr2line import BacktraceResolver, set_debug, debug
 
 class StdinBacktraceIterator(object):
     """
@@ -123,6 +123,13 @@ cmdline_parser.add_argument(
         ' it originates from, as well as the address being resolved')
 
 cmdline_parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        default=False,
+        help='Emit debugging information to stderr')
+
+cmdline_parser.add_argument(
         '-t',
         '--test',
         action='store_true',
@@ -137,6 +144,11 @@ cmdline_parser.add_argument(
         help='Addresses to parse')
 
 args = cmdline_parser.parse_args()
+
+if (args.debug):
+    set_debug(True)
+
+debug('debug output enabled')
 
 if args.test:
     data = [


### PR DESCRIPTION
Previously we used 0x0 as a sentinel at the end of every address
sent to addr2line, but this fails with some binaries (e.g., redpanda
compiled with clang 14) because 0 actually resolves to something.

Instead just use a string like 'sentinel' as the sentinel since
addr2line (and llvm-addr2line) just echos these unchanged.
