### PR TITLE
Allow for multiple metrics endpoints

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -172,9 +172,10 @@ struct metric_info {
 using metrics_registration = std::vector<metric_id>;
 
 class metric_groups_impl : public metric_groups_def {
+    int _handle;
     metrics_registration _registration;
 public:
-    metric_groups_impl() = default;
+    explicit metric_groups_impl(int handle = default_handle());
     ~metric_groups_impl();
     metric_groups_impl(const metric_groups_impl&) = delete;
     metric_groups_impl(metric_groups_impl&&) = default;
@@ -192,7 +193,7 @@ class registered_metric {
     metric_function _f;
     shared_ptr<impl> _impl;
 public:
-    registered_metric(metric_id id, metric_function f, bool enabled=true, bool skip_when_empty=false);
+    registered_metric(metric_id id, metric_function f, bool enabled=true, bool skip_when_empty=false, int handle=default_handle());
     virtual ~registered_metric() {}
     virtual metric_value operator()() const {
         return _f();
@@ -339,7 +340,7 @@ public:
         return _value_map;
     }
 
-    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, bool skip_when_empty, const std::vector<std::string>& aggregate_labels);
+    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, bool skip_when_empty, const std::vector<std::string>& aggregate_labels, int handle = default_handle());
     void remove_registration(const metric_id& id);
     future<> stop() {
         return make_ready_future<>();
@@ -362,14 +363,15 @@ public:
     }
 };
 
-const value_map& get_value_map();
+const value_map& get_value_map(int handle = default_handle());
 using values_reference = shared_ptr<values_copy>;
 
-foreign_ptr<values_reference> get_values();
+foreign_ptr<values_reference> get_values(int handle = default_handle());
 
 shared_ptr<impl> get_local_impl(int handle = default_handle());
 
-void unregister_metric(const metric_id & id);
+
+void unregister_metric(const metric_id & id, int handle = default_handle());
 
 /*!
  * \brief initialize metric group
@@ -377,7 +379,7 @@ void unregister_metric(const metric_id & id);
  * Create a metric_group_def.
  * No need to use it directly.
  */
-std::unique_ptr<metric_groups_def> create_metric_groups();
+std::unique_ptr<metric_groups_def> create_metric_groups(int handle = default_handle());
 
 }
 
@@ -394,7 +396,7 @@ struct options : public program_options::option_group {
 /*!
  * \brief set the metrics configuration
  */
-future<> configure(const options& opts);
+future<> configure(const options& opts, int handle = default_handle());
 
 }
 }

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -37,6 +37,9 @@ namespace metrics {
 namespace impl {
 
 using labels_type = std::map<sstring, sstring>;
+
+int default_handle();
+
 }
 }
 }
@@ -181,6 +184,8 @@ public:
 };
 
 class impl;
+using metric_implementations = std::unordered_map<int, ::seastar::shared_ptr<impl>>;
+metric_implementations& get_metric_implementations();
 
 class registered_metric {
     metric_info _info;
@@ -362,7 +367,7 @@ using values_reference = shared_ptr<values_copy>;
 
 foreign_ptr<values_reference> get_values();
 
-shared_ptr<impl> get_local_impl();
+shared_ptr<impl> get_local_impl(int handle = default_handle());
 
 void unregister_metric(const metric_id & id);
 

--- a/include/seastar/core/metrics_registration.hh
+++ b/include/seastar/core/metrics_registration.hh
@@ -51,6 +51,7 @@ namespace seastar {
 namespace metrics {
 
 namespace impl {
+int default_handle();
 class metric_groups_def;
 struct metric_definition_impl;
 class metric_groups_impl;

--- a/include/seastar/core/metrics_registration.hh
+++ b/include/seastar/core/metrics_registration.hh
@@ -57,6 +57,8 @@ struct metric_definition_impl;
 class metric_groups_impl;
 }
 
+int default_handle();
+
 using group_name_type = sstring; /*!< A group of logically related metrics */
 class metric_groups;
 
@@ -90,7 +92,7 @@ public:
 class metric_groups {
     std::unique_ptr<impl::metric_groups_def> _impl;
 public:
-    metric_groups() noexcept;
+    explicit metric_groups(int handle = default_handle()) noexcept;
     metric_groups(metric_groups&&) = default;
     virtual ~metric_groups();
     metric_groups& operator=(metric_groups&&) = default;
@@ -99,7 +101,7 @@ public:
      *
      * combine the constructor with the add_group functionality.
      */
-    metric_groups(std::initializer_list<metric_group_definition> mg);
+    metric_groups(std::initializer_list<metric_group_definition> mg, int handle = default_handle());
 
     /*!
      * \brief Add metrics belonging to the same group.
@@ -155,7 +157,7 @@ public:
  */
 class metric_group : public metric_groups {
 public:
-    metric_group() noexcept;
+    explicit metric_group(int handle = default_handle()) noexcept;
     metric_group(const metric_group&) = delete;
     metric_group(metric_group&&) = default;
     virtual ~metric_group();
@@ -166,7 +168,7 @@ public:
      *
      *
      */
-    metric_group(const group_name_type& name, std::initializer_list<metric_definition> l);
+    metric_group(const group_name_type& name, std::initializer_list<metric_definition> l, int handle = default_handle());
 };
 
 

--- a/include/seastar/core/prometheus.hh
+++ b/include/seastar/core/prometheus.hh
@@ -37,11 +37,13 @@ struct config {
     sstring hostname; //!< hostname is deprecated, use label instead
     std::optional<metrics::label_instance> label; //!< A label that will be added to all metrics, we advice not to use it and set it on the prometheus server
     sstring prefix = "seastar"; //!< a prefix that will be added to metric names
+    int handle = metrics::default_handle(); //!< Handle that specifies which metric implementation to query
+    sstring route = "/metrics"; //!< Name of the route on which to expose the metrics
 };
 
 future<> start(httpd::http_server_control& http_server, config ctx);
 
-/// \defgroup add_prometheus_routes adds a /metrics endpoint that returns prometheus metrics
+/// \defgroup add_prometheus_routes adds a specified endpoint (defaults to /metrics) that returns prometheus metrics
 ///    in txt format
 /// @{
 future<> add_prometheus_routes(distributed<http_server>& server, config ctx);

--- a/include/seastar/core/scollectd.hh
+++ b/include/seastar/core/scollectd.hh
@@ -371,7 +371,7 @@ struct options : public program_options::option_group {
     /// \endcond
 };
 
-void configure(const options&);
+void configure(const options&, int handle = seastar::metrics::default_handle());
 void remove_polled_metric(const type_instance_id &);
 
 class plugin_instance_metrics;
@@ -390,8 +390,8 @@ class plugin_instance_metrics;
  */
 struct registration {
     registration() = default;
-    registration(const type_instance_id& id);
-    registration(type_instance_id&& id);
+    registration(const type_instance_id& id, int handle = seastar::metrics::default_handle());
+    registration(type_instance_id&& id, int handle = seastar::metrics::default_handle());
     registration(const registration&) = delete;
     registration(registration&&) = default;
     ~registration();
@@ -798,8 +798,8 @@ seastar::metrics::impl::metric_id to_metrics_id(const type_instance_id & id);
  */
 template<typename Arg>
 [[deprecated("Use the metrics layer")]] static type_instance_id add_polled_metric(const type_instance_id & id, description d,
-        Arg&& arg, bool enabled = true) {
-    seastar::metrics::impl::get_local_impl()->add_registration(to_metrics_id(id), arg.type, seastar::metrics::impl::make_function(arg.value, arg.type), d, enabled);
+        Arg&& arg, bool enabled = true, int handle = seastar::metrics::default_handle()) {
+    seastar::metrics::impl::get_local_impl(handle)->add_registration(to_metrics_id(id), arg.type, seastar::metrics::impl::make_function(arg.value, arg.type), d, enabled);
     return id;
 }
 /*!

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -650,7 +650,7 @@ void io_queue::register_stats(sstring name, priority_class_data& pc) {
     }
 
     new_metrics.add_group("io_queue", std::move(metrics));
-    pc.metric_groups = std::exchange(new_metrics, {});
+    pc.metric_groups = std::exchange(new_metrics, sm::metric_groups{});
 }
 
 io_queue::priority_class_data& io_queue::find_or_create_class(const io_priority_class& pc) {

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -241,13 +241,17 @@ bool metric_id::operator==(
     return as_tuple() == id2.as_tuple();
 }
 
-// Unfortunately, metrics_impl can not be shared because it
-// need to be available before the first users (reactor) will call it
+shared_ptr<impl> get_local_impl(int handle) {
+    auto& impls = get_metric_implementations();
+    auto [it, inserted] = impls.try_emplace(handle);
 
-shared_ptr<impl>  get_local_impl() {
-    static thread_local auto the_impl = ::seastar::make_shared<impl>();
-    return the_impl;
+    if (inserted) {
+        it->second = ::seastar::make_shared<impl>();
+    }
+
+    return it->second;
 }
+
 void impl::remove_registration(const metric_id& id) {
     auto i = get_value_map().find(id.full_name());
     if (i != get_value_map().end()) {
@@ -363,6 +367,10 @@ void impl::add_registration(const metric_id& id, const metric_type& type, metric
         _value_map[name][id.labels()] = rm;
     }
     dirty();
+}
+
+int default_handle() {
+    return 0;
 }
 
 }

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -284,8 +284,11 @@ foreign_ptr<values_reference> get_values(int handle) {
     shared_ptr<values_copy> res_ref = ::seastar::make_shared<values_copy>();
     auto& res = *(res_ref.get());
     auto& mv = res.values;
-    res.metadata = get_local_impl(handle)->metadata();
-    auto & functions = get_local_impl(handle)->functions();
+
+    auto impl = get_local_impl(handle);
+    res.metadata = impl->metadata();
+    auto & functions = impl->functions();
+
     mv.reserve(functions.size());
     for (auto&& i : functions) {
         value_vector values;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3544,6 +3544,12 @@ smp_options::smp_options(program_options::option_group* parent_group)
 {
 }
 
+thread_local metrics::impl::metric_implementations metric_impls;
+
+metrics::impl::metric_implementations& metrics::impl::get_metric_implementations() {
+    return metric_impls;
+}
+
 thread_local scollectd::impl scollectd_impl;
 
 scollectd::impl & scollectd::get_impl() {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -866,7 +866,7 @@ reactor::task_queue::register_stats() {
         }, sm::description("Total amount in milliseconds we were in violation of the task quota"),
            {group_label}),
     });
-    _metrics = std::exchange(new_metrics, {});
+    _metrics = std::exchange(new_metrics, sm::metric_groups{});
 }
 
 void

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -76,12 +76,12 @@ registration::~registration() {
     unregister();
 }
 
-registration::registration(const type_instance_id& id)
-: _id(id), _impl(seastar::metrics::impl::get_local_impl()) {
+registration::registration(const type_instance_id& id, int handle)
+: _id(id), _impl(seastar::metrics::impl::get_local_impl(handle)) {
 }
 
-registration::registration(type_instance_id&& id)
-: _id(std::move(id)), _impl(seastar::metrics::impl::get_local_impl()) {
+registration::registration(type_instance_id&& id, int handle)
+: _id(std::move(id)), _impl(seastar::metrics::impl::get_local_impl(handle)) {
 }
 
 seastar::metrics::impl::metric_id to_metrics_id(const type_instance_id & id) {
@@ -524,7 +524,7 @@ future<> send_metric(const type_instance_id & id,
     return get_impl().send_metric(id, values);
 }
 
-void configure(const options& opts) {
+void configure(const options& opts, int handle) {
     bool enable = opts.collectd.get_value();
     if (!enable) {
         return;
@@ -533,7 +533,7 @@ void configure(const options& opts) {
     auto period = std::chrono::milliseconds(opts.collectd_poll_period.get_value());
 
     auto host = (opts.collectd_hostname.get_value() == "")
-            ? seastar::metrics::impl::get_local_impl()->get_config().hostname
+            ? seastar::metrics::impl::get_local_impl(handle)->get_config().hostname
             : sstring(opts.collectd_hostname.get_value());
 
     // Now create send loops on each cpu


### PR DESCRIPTION
Previously, seastar collected all metrics (and metrics related metadata) in a single object (`metrics::impl::impl`). The consequence of this is that there was no way to have multiple metrics namespaces and expose each namespace through its own prometheus endpoint. If an application published a large volume of metrics, the user had to filter them by using by using the `name` request parameter of the prometheus endpoint. The downside of this approach is that the user must have knowledge of the metrics set and, even in that case,  some queries cannot be expressed in terms of substring matching (i.e. the existing filtering implementation).

A more flexible approach is to allow applications to categorise metrics at the time of registering them and expose the different metrics set on different prometheus endpoints if required. This is the approach taken for this PR. The metrics registration api
now allows applications to specify the internal metrics implementation (think of it as a metrics bucket) via an integer handle. Internally, whenever a shard needs to handle a metric related operation for a handle it hasn't seen before, a new `metrics::impl::impl` object is created on the fly. This leads to a simple api, as applications don't need to pre-register metric implementation before adding groups.

Here is an example of how to add metric groups to a specific "bucket" and expose each "bucket" on a prometheus endpoint.
Metrics in the `foo` group will be exposed on the default `metric` prometheus endpoint, while the `baz` group will be exposed
on the `extra_metrics` endpoint.
```
auto extra_metrics_handle = 100;

ss::metrics::metric_groups metrics;
metrics.add_group(
  "foo", {sm::make_gauge("bar", [] { return 1; }, sm::description("foobar metric")}); 
  
ss::metrics::metric_groups metrics2(extra_metrics_handle);
metrics2.add_group(
  "baz", {sm::make_gauge("daz", [] { return 1; }, sm::description("bazdaz metric")});

...
ss::prometheus::config default;
default.prefix = "default metrics bucket";

ss::prometheus::config extra;
extra.prefix = "extra metrics bucket";
extra.handle = extra_metrics_handle;
extra.route = "metrics_v100";

seastar::prometheus::add_prometheus_routes(your_server, default).get();
seastar::prometheus::add_prometheus_routes(your_server, extra).get();
```

NB: Previous PR [here](https://github.com/redpanda-data/seastar/pull/23)

[force push](https://github.com/redpanda-data/seastar/compare/db7d98a9dc9c6c24cb8b9b4d5873506fb00b21e8..ccbdea2cd6871db6dd49e538e9ce5739cb7836fd):
* Use a `std::unordered_map` for storing the metric implementations. This allows for the removal of
the handle from the implementation object itself.

[force push](https://github.com/redpanda-data/seastar/compare/ccbdea2cd6871db6dd49e538e9ce5739cb7836fd..0298ea2747a5acddca662e78d09cd28fc42d3d91):
* reduced number of lookups in impl map by using `try_emplace`
* added a `default_handle` function to the public metrics interface
* fixed comment typos in prometheus.cc
* removed subsequent calls to `get_local_impl`

[force push](https://github.com/redpanda-data/seastar/blob/020c9ba4e709f816110d7ddf819fd97dd6833c69/src/core/metrics.cc):
* Moved the handle to the `metric_groups` level. Previously, each group within a `metric_groups` could be
associated with its own metrics implementation. It makes more sense for all the groups within a `metric_groups`
object to push metrics into the same internal object.

[force push](https://github.com/redpanda-data/seastar/compare/020c9ba4e709f816110d7ddf819fd97dd6833c69..ae95909f9a30106abee884eed5ca940ddf6dc38e):
* explicit constructors

[force push](https://github.com/redpanda-data/seastar/compare/ae95909f9a30106abee884eed5ca940ddf6dc38e..d91b99510439817187ae31e2e1779b31d226ab65):
* Use `seastar::metrics::default_handle` instead of  `seastar::metrics::impl::default_handle`
* Explicitly call `metric_groups` constructor where it was called implicitly

[force push](https://github.com/redpanda-data/seastar/compare/d91b99510439817187ae31e2e1779b31d226ab65..91129e28f80de9b664237287859a6d2945ef0173):
* Rebased on top of `v22.2.x` and fixed merge conflicts. This mostly consisted of moving the `handle`
argument, that was added to much of the metrics interface, behind the `skip_when_empty` argument.