### PR TITLE
Add metrics aggregation capabilities

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -256,6 +256,7 @@ enum class data_type : uint8_t {
     REAL_COUNTER,
     GAUGE,
     HISTOGRAM,
+    SUMMARY,
 };
 
 template <bool callable, typename T>
@@ -593,6 +594,18 @@ template<typename T>
 impl::metric_definition_impl make_histogram(metric_name_type name,
         description d, T&& val) {
     return  {name, {impl::data_type::HISTOGRAM, "histogram"}, make_function(std::forward<T>(val), impl::data_type::HISTOGRAM), d, {}};
+}
+
+/*!
+ * \brief create a summary metric.
+ *
+ * Summaries are a different kind of histograms. It reports in quantiles.
+ * For example, the p99 and p95 latencies.
+ */
+template<typename T>
+impl::metric_definition_impl make_summary(metric_name_type name,
+        description d, T&& val) {
+    return  {name, {impl::data_type::SUMMARY, "summary"}, make_function(std::forward<T>(val), impl::data_type::SUMMARY), d, {}};
 }
 
 

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -152,6 +152,7 @@ struct metric_family_info {
     metric_type_def inherit_type;
     description d;
     sstring name;
+    std::vector<std::string> aggregate_labels;
 };
 
 
@@ -161,6 +162,7 @@ struct metric_family_info {
 struct metric_info {
     metric_id id;
     bool enabled;
+    bool skip_when_empty;
 };
 
 
@@ -185,7 +187,7 @@ class registered_metric {
     metric_function _f;
     shared_ptr<impl> _impl;
 public:
-    registered_metric(metric_id id, metric_function f, bool enabled=true);
+    registered_metric(metric_id id, metric_function f, bool enabled=true, bool skip_when_empty=false);
     virtual ~registered_metric() {}
     virtual metric_value operator()() const {
         return _f();
@@ -198,7 +200,9 @@ public:
     void set_enabled(bool b) {
         _info.enabled = b;
     }
-
+    void set_skip_when_empty(bool skip) {
+        _info.skip_when_empty = skip;
+    }
     const metric_id& get_id() const {
         return _info.id;
     }
@@ -330,7 +334,7 @@ public:
         return _value_map;
     }
 
-    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled);
+    void add_registration(const metric_id& id, const metric_type& type, metric_function f, const description& d, bool enabled, bool skip_when_empty, const std::vector<std::string>& aggregate_labels);
     void remove_registration(const metric_id& id);
     future<> stop() {
         return make_ready_future<>();

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -365,6 +365,8 @@ histogram& histogram::operator+=(const histogram& c) {
             buckets[i].count += c.buckets[i].count;
         }
     }
+    sample_count += c.sample_count;
+    sample_sum += c.sample_sum;
     return *this;
 }
 

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -51,6 +51,8 @@ static std::string to_str(seastar::metrics::impl::data_type dt) {
         return "counter";
     case seastar::metrics::impl::data_type::HISTOGRAM:
         return "histogram";
+    case seastar::metrics::impl::data_type::SUMMARY:
+        return "summary";
     }
     return "untyped";
 }
@@ -63,6 +65,7 @@ static std::string to_str(const seastar::metrics::impl::metric_value& v) {
     case seastar::metrics::impl::data_type::COUNTER:
         return std::to_string(v.i());
     case seastar::metrics::impl::data_type::HISTOGRAM:
+    case seastar::metrics::impl::data_type::SUMMARY:
         break;
     }
     return ""; // we should never get here but it makes the compiler happy
@@ -478,14 +481,123 @@ metric_family_range get_range(const metrics_families_per_shard& mf, const sstrin
 
 }
 
+void write_histogram(std::stringstream& s, const config& ctx, const sstring& name, const seastar::metrics::histogram& h, std::map<sstring, sstring> labels) {
+    add_name(s, name + "_sum", labels, ctx);
+    s << h.sample_sum;
+    s << "\n";
+    add_name(s, name + "_count", labels, ctx);
+    s << h.sample_count;
+    s << "\n";
+
+    auto& le = labels["le"];
+    auto bucket = name + "_bucket";
+    for (auto  i : h.buckets) {
+         le = std::to_string(i.upper_bound);
+        add_name(s, bucket, labels, ctx);
+        s << i.count;
+        s << "\n";
+    }
+    labels["le"] = "+Inf";
+    add_name(s, bucket, labels, ctx);
+    s << h.sample_count;
+    s << "\n";
+}
+
+void write_summary(std::stringstream& s, const config& ctx, const sstring& name, const seastar::metrics::histogram& h, std::map<sstring, sstring> labels) {
+    if (h.sample_sum) {
+        add_name(s, name + "_sum", labels, ctx);
+        s << h.sample_sum;
+        s << "\n";
+    }
+    if (h.sample_count) {
+        add_name(s, name + "_count", labels, ctx);
+        s << h.sample_count;
+        s << "\n";
+    }
+    auto& le = labels["quantile"];
+    for (auto  i : h.buckets) {
+        le = std::to_string(i.upper_bound);
+        add_name(s, name, labels, ctx);
+        s << i.count;
+        s << "\n";
+    }
+}
+/*!
+ * \brief a helper class to aggregate metrics over labels
+ *
+ * This class sum multiple metrics based on a list of labels.
+ * It returns one or more metrics each aggregated by the aggregate_by labels.
+ *
+ * To use it, you define what labels it should aggregate by and then pass to
+ * it metrics with their labels.
+ * For example if a metrics has a 'shard' and 'name' labels and you aggregate by 'shard'
+ * it would return a map of metrics each with only the 'name' label
+ *
+ */
+class metric_aggregate_by_labels {
+    std::vector<std::string> _labels_to_aggregate_by;
+    std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value> _values;
+public:
+    metric_aggregate_by_labels(std::vector<std::string>  labels) : _labels_to_aggregate_by(std::move(labels)) {
+    }
+    /*!
+     * \brief add a metric
+     *
+     * This method gets a metric and its labels and add it to the aggregated metric.
+     * For example, if a metric has the labels {'shard':'0', 'name':'myhist'} and we are aggregating
+     * over 'shard'
+     * The metric would be added to the aggregated metric with labels {'name':'myhist'}.
+     *
+     */
+    void add(const seastar::metrics::impl::metric_value& m, std::map<sstring, sstring> labels) {
+        for (auto&& l : _labels_to_aggregate_by) {
+            labels.erase(l);
+        }
+        if (_values.find(labels) == _values.end()) {
+            _values.emplace(labels, m);
+        } else {
+            _values[labels] += m;
+        }
+    }
+    const std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value>& get_values() const {
+        return _values;
+    }
+    bool empty() const {
+        return _values.empty();
+    }
+};
+
+std::string get_value_as_string(std::stringstream& s, const mi::metric_value& value) {
+    std::string value_str;
+    try {
+        value_str = to_str(value);
+    } catch (const std::range_error& e) {
+        seastar_logger.debug("prometheus: write_text_representation: {}: {}", s.str(), e.what());
+        value_str = "NaN";
+    } catch (...) {
+        auto ex = std::current_exception();
+        // print this error as it's ignored later on by `connection::start_response`
+        seastar_logger.error("prometheus: write_text_representation: {}: {}", s.str(), ex);
+        std::rethrow_exception(std::move(ex));
+    }
+    return value_str;
+}
+
 future<> write_text_representation(output_stream<char>& out, const config& ctx, const metric_family_range& m) {
     return seastar::async([&ctx, &out, &m] () mutable {
         bool found = false;
+        std::stringstream s;
         for (metric_family& metric_family : m) {
             auto name = ctx.prefix + "_" + metric_family.name();
             found = false;
-            metric_family.foreach_metric([&out, &ctx, &found, &name, &metric_family](auto value, auto value_info) mutable {
-                std::stringstream s;
+            metric_aggregate_by_labels aggregated_values(metric_family.metadata().aggregate_labels);
+            bool should_aggregate = !metric_family.metadata().aggregate_labels.empty();
+            metric_family.foreach_metric([&s, &out, &ctx, &found, &name, &metric_family, &aggregated_values, should_aggregate](auto value, auto value_info) mutable {
+                s.clear();
+                s.str("");
+                if (value_info.skip_when_empty && value.is_empty()) {
+                    return;
+                }
                 if (!found) {
                     if (metric_family.metadata().d.str() != "") {
                         s << "# HELP " << name << " " <<  metric_family.metadata().d.str() << "\n";
@@ -493,48 +605,35 @@ future<> write_text_representation(output_stream<char>& out, const config& ctx, 
                     s << "# TYPE " << name << " " << to_str(metric_family.metadata().type) << "\n";
                     found = true;
                 }
-                if (value.type() == mi::data_type::HISTOGRAM) {
-                    auto&& h = value.get_histogram();
-                    std::map<sstring, sstring> labels = value_info.id.labels();
-                    add_name(s, name + "_sum", labels, ctx);
-                    s << h.sample_sum;
-                    s << "\n";
-                    add_name(s, name + "_count", labels, ctx);
-                    s << h.sample_count;
-                    s << "\n";
-
-                    auto& le = labels["le"];
-                    auto bucket = name + "_bucket";
-                    for (auto  i : h.buckets) {
-                         le = std::to_string(i.upper_bound);
-                        add_name(s, bucket, labels, ctx);
-                        s << i.count;
-                        s << "\n";
-                    }
-                    labels["le"] = "+Inf";
-                    add_name(s, bucket, labels, ctx);
-                    s << h.sample_count;
-                    s << "\n";
+                if (should_aggregate) {
+                    aggregated_values.add(value, value_info.id.labels());
+                } else if (value.type() == mi::data_type::SUMMARY) {
+                    write_summary(s, ctx, name, value.get_histogram(), value_info.id.labels());
+                } else if (value.type() == mi::data_type::HISTOGRAM) {
+                    write_histogram(s, ctx, name, value.get_histogram(), value_info.id.labels());
                 } else {
                     add_name(s, name, value_info.id.labels(), ctx);
-                    std::string value_str;
-                    try {
-                        value_str = to_str(value);
-                    } catch (const std::range_error& e) {
-                        seastar_logger.debug("prometheus: write_text_representation: {}: {}", s.str(), e.what());
-                        value_str = "NaN";
-                    } catch (...) {
-                        auto ex = std::current_exception();
-                        // print this error as it's ignored later on by `connection::start_response`
-                        seastar_logger.error("prometheus: write_text_representation: {}: {}", s.str(), ex);
-                        std::rethrow_exception(std::move(ex));
-                    }
-                    s << value_str;
+                    s << get_value_as_string(s, value);
                     s << "\n";
                 }
                 out.write(s.str()).get();
                 thread::maybe_yield();
             });
+            if (!aggregated_values.empty()) {
+                for (auto&& h : aggregated_values.get_values()) {
+                    s.clear();
+                    s.str("");
+                    if (h.second.type() == mi::data_type::HISTOGRAM) {
+                        write_histogram(s, ctx, name, h.second.get_histogram(), h.first);
+                    } else {
+                        add_name(s, name, h.first, ctx);
+                        s << get_value_as_string(s, h.second);
+                        s << "\n";
+                    }
+                    out.write(s.str()).get();
+                    thread::maybe_yield();
+                }
+            }
         }
     });
 }


### PR DESCRIPTION
This PR contains a set of patches from the seastar mailing list ([patch set](https://groups.google.com/u/0/g/seastar-dev/c/qrlkP5y8JXw) and [repo](https://github.com/amnonh/seastar/tree/metrics_summary)). They add aggregations
support to the seastar metrics subsystem. This PR used to be based on an older version of the upstream patch set,
but Ben fed back our findings and the new version matches our needs as is.

#### Mailing List Cover Letter

Motivation:
Histograms are the Prometheus killer. They are big to send over the
network and are big to store in Prometheus.
Histograms' size is always an issue, but with Seastar, it becomes even trickier.
Typically, each shard would collect its histograms, so the overall data
is multiplied by the number of shards.

This series addresses the need to report quantile information like latency
without generating massive metrics reports.

A summary is a Prometheus metric type that holds a quantile summary (i.e.
p95, p99).

The downside of summaries is that they cannot be aggregated, which is
needed for a distributed system (i.e., calculate the p99 latency of a cluster).

The series adds four tools for Prometheus performance:
1. Add summaries.
2. Optionally, remove empty metrics. It's common to register metrics for
optional services. It is now possible to mark those metrics as
skip_when_empty and they will not be reported if they were never used.
3. Allow aggregating metrics. The most common case is reporting per-node
metrics instead of per shard. For example, for multi-nodes quantile calculation,
we need a per-node histogram. It is now possible to mark a registered
metric for aggregation. The metrics layer will aggregate this
metric based on a list of labels. (Typically, this will be by shard,
but it could be any other combination of labels).
4. Reuse the stringstream instead of recreating an object on each
iteration. 

[force push](https://github.com/redpanda-data/seastar/compare/57f55f820582c843e978575c4c9fe08fd3ea9b15..b45c02b0a2ffc9278c2cd54d04512df9c53ed9a6):
* split into smaller commits
* use `sm::label` strong type instead of `std::string` for specifying aggregation labels
* reuse string stream when converting aggregated metrics to text

[force push](https://github.com/redpanda-data/seastar/compare/b45c02b0a2ffc9278c2cd54d04512df9c53ed9a6..2db661da9fca890e2133e18c2b325aa7040d4641):
* Remove `aggregation_labels` argument from metric creation functions (`make_<metric_type>`).

[force push](https://github.com/redpanda-data/seastar/compare/2db661da9fca890e2133e18c2b325aa7040d4641..1729479a908195548700727c6bb6c5020f4334e6):
* Use the `write_counter` function in the commit it's introduced

[force push](https://github.com/redpanda-data/seastar/compare/1729479a908195548700727c6bb6c5020f4334e6..c8de0aea412268e0346b237fd51a4d3e5d1c8f93):
* Use strong label type `sm::label` in setter of aggregation labels

[force push](https://github.com/redpanda-data/seastar/compare/c8de0aea412268e0346b237fd51a4d3e5d1c8f93..3f3582035d3d62924e936f71e059dcd53564de7d):
* Amnon's latest version of the [patch set](https://groups.google.com/u/0/g/seastar-dev/c/qrlkP5y8JXw) includes everything we need and is functionally
equivalent to what we had on this branch before (it also allows for skipping reporting of
empty metrics configurably).