### PR TITLE
Metric replication accross internal implementations

### DIFF
--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -368,6 +368,23 @@ public:
         _dirty = true;
     }
 
+
+    // Set the metrics families to be replicated from this metrics::impl.
+    // All metrics families that match one of the keys of
+    // the 'metric_families_to_replicate' argument will be replicated
+    // on the metrics::impl identified by the corresponding value.
+    //
+    // If this function was called previously, any previously
+    // replicated metrics will be removed before the provided ones are
+    // replicated.
+    //
+    // Metric replication spans the full life cycle of this class.
+    // Newly registered metrics that belong to a replicated family
+    // be replicated too and unregistering a replicated metric will
+    // unregister the replica.
+    void set_metric_families_to_replicate(
+            std::unordered_multimap<seastar::sstring, int> metric_families_to_replicate);
+
 private:
     void replicate_metric_family(const seastar::sstring& name,
                                  int destination_handle) const;

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -209,6 +209,11 @@ public:
     void set_skip_when_empty(bool skip) {
         _info.skip_when_empty = skip;
     }
+
+    bool get_skip_when_empty() const {
+        return _info.skip_when_empty;
+    }
+
     const metric_id& get_id() const {
         return _info.id;
     }

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -436,5 +436,12 @@ struct options : public program_options::option_group {
  */
 future<> configure(const options& opts, int handle = default_handle());
 
+
+/*!
+ * \brief replicate metric families accross internal metrics implementations
+ */
+future<>
+replicate_metric_families(int source_handle, std::unordered_multimap<seastar::sstring, int> metric_families_to_replicate);
+
 }
 }

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -336,6 +336,7 @@ class impl {
     bool _dirty = true;
     shared_ptr<metric_metadata> _metadata;
     std::vector<std::vector<metric_function>> _current_metrics;
+    std::unordered_multimap<seastar::sstring, int> _metric_families_to_replicate;
 public:
     value_map& get_value_map() {
         return _value_map;
@@ -366,6 +367,16 @@ public:
     void dirty() {
         _dirty = true;
     }
+
+private:
+    void replicate_metric_family(const seastar::sstring& name,
+                                 int destination_handle) const;
+    void replicate_metric_if_required(const shared_ptr<registered_metric>& metric) const;
+    void replicate_metric(const shared_ptr<registered_metric>& metric,
+                          const metric_family& family,
+                          const shared_ptr<impl>& destination,
+                          int destination_handle) const;
+
 };
 
 const value_map& get_value_map(int handle = default_handle());

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -377,6 +377,11 @@ private:
                           const shared_ptr<impl>& destination,
                           int destination_handle) const;
 
+    void remove_metric_replica_family(const seastar::sstring& name,
+                                      int destination_handle) const;
+    void remove_metric_replica(const metric_id& id,
+                               const shared_ptr<impl>& destination) const;
+    void remove_metric_replica_if_required(const metric_id& id) const;
 };
 
 const value_map& get_value_map(int handle = default_handle());

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -258,6 +258,8 @@ shared_ptr<impl> get_local_impl(int handle) {
 }
 
 void impl::remove_registration(const metric_id& id) {
+    remove_metric_replica_if_required(id);
+
     auto i = get_value_map().find(id.full_name());
     if (i != get_value_map().end()) {
         auto j = i->second.find(id.labels());
@@ -467,6 +469,8 @@ void impl::add_registration(const metric_id& id, const metric_type& type, metric
         _value_map[name][id.labels()] = rm;
     }
     dirty();
+
+    replicate_metric_if_required(rm);
 }
 
 int default_handle() {

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -310,6 +310,52 @@ instance_id_type shard() {
     return sstring("0");
 }
 
+void impl::replicate_metric_family(const seastar::sstring& name,
+                                   int destination_handle) const {
+    const auto& entry = _value_map.find(name);
+
+    if (entry == _value_map.end()) {
+        return;
+    }
+
+    const auto& metric_family = entry->second;
+    auto destination = get_local_impl(destination_handle);
+    for (const auto& [labels, metric_ptr]: metric_family) {
+        replicate_metric(metric_ptr, metric_family, destination, destination_handle);
+    }
+}
+
+void impl::replicate_metric_if_required(const shared_ptr<registered_metric>& metric) const {
+    auto full_name = metric->get_id().full_name();
+    auto [begin, end]= _metric_families_to_replicate.equal_range(full_name);
+
+    for (; begin != end; ++begin) {
+        const auto& [name, destination_handle] = *begin;
+        const auto& metric_family = _value_map.at(name);
+
+        auto destination = get_local_impl(destination_handle);
+        replicate_metric(metric, metric_family, destination, destination_handle);
+    }
+}
+
+void impl::replicate_metric(const shared_ptr<registered_metric>& metric,
+                            const metric_family& family,
+                            const shared_ptr<impl>& destination,
+                            int destination_handle) const {
+    const auto& family_info = family.info();
+    metric_type type = { .base_type = family_info.type,
+                         .type_name = family_info.inherit_type };
+
+    destination->add_registration(metric->get_id(),
+                                  type,
+                                  metric->get_function(),
+                                  family_info.d,
+                                  metric->is_enabled(),
+                                  metric->get_skip_when_empty(),
+                                  family_info.aggregate_labels,
+                                  destination_handle);
+}
+
 void impl::update_metrics_if_needed() {
     if (_dirty) {
         // Forcing the metadata to an empty initialization

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -272,6 +272,36 @@ void impl::remove_registration(const metric_id& id) {
     }
 }
 
+void impl::remove_metric_replica_family(const seastar::sstring& name,
+                                        int destination_handle) const {
+    auto entry = _value_map.find(name);
+
+    if (entry == _value_map.end()) {
+        return;
+    }
+
+    auto destination = get_local_impl(destination_handle);
+    for (const auto& metric_instance: entry->second) {
+        const auto& registered_metric = metric_instance.second;
+        remove_metric_replica(registered_metric->get_id(),
+                              destination);
+    }
+}
+
+void impl::remove_metric_replica(const metric_id& id,
+                                 const shared_ptr<impl>& destination) const {
+    destination->remove_registration(id);
+}
+
+void impl::remove_metric_replica_if_required(const metric_id& id) const {
+    auto [begin, end] = _metric_families_to_replicate.equal_range(id.full_name());
+
+    for (; begin != end; ++begin) {
+        auto destination = get_local_impl(begin->second);
+        remove_metric_replica(id, destination);
+    }
+}
+
 void unregister_metric(const metric_id & id, int handle) {
     get_local_impl(handle)->remove_registration(id);
 }

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -340,6 +340,22 @@ instance_id_type shard() {
     return sstring("0");
 }
 
+void
+impl::set_metric_families_to_replicate(
+        std::unordered_multimap<seastar::sstring, int> metric_families_to_replicate) {
+    // Remove all previous metric replica families
+    for (const auto& [name, destination]: _metric_families_to_replicate) {
+        remove_metric_replica_family(name, destination);
+    }
+
+    // Replicate the specified metric families.
+    for (const auto& [name, destination]: metric_families_to_replicate) {
+        replicate_metric_family(name, destination);
+    }
+
+    _metric_families_to_replicate = std::move(metric_families_to_replicate);
+}
+
 void impl::replicate_metric_family(const seastar::sstring& name,
                                    int destination_handle) const {
     const auto& entry = _value_map.find(name);

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -112,6 +112,17 @@ future<> configure(const options& opts, int handle) {
     });
 }
 
+future<>
+replicate_metric_families(
+        int source_handle,
+        std::unordered_multimap<seastar::sstring, int> metric_families_to_replicate) {
+    return smp::invoke_on_all([source_handle, metric_families_to_replicate] {
+        auto source_impl = impl::get_local_impl(source_handle);
+        source_impl->set_metric_families_to_replicate(
+                std::move(metric_families_to_replicate));
+    });
+}
+
 bool label_instance::operator!=(const label_instance& id2) const {
     auto& id1 = *this;
     return !(id1 == id2);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -350,6 +350,9 @@ seastar_add_test (lowres_clock
 seastar_add_test (metrics
   SOURCES metrics_test.cc)
 
+seastar_add_test (metrics_family_replication
+  SOURCES metric_family_replication_test.cc)
+
 seastar_add_test (net_config
   KIND BOOST
   SOURCES net_config_test.cc)

--- a/tests/unit/metric_family_replication_test.cc
+++ b/tests/unit/metric_family_replication_test.cc
@@ -1,0 +1,96 @@
+#include <seastar/core/metrics.hh>
+#include <seastar/core/metrics_api.hh>
+#include <seastar/core/metrics_registration.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/test_runner.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+namespace sm = seastar::metrics;
+namespace smi = seastar::metrics::impl;
+
+bool metric_family_exists(int handle, const seastar::sstring& name) {
+    return smi::get_value_map(handle).contains(name);
+}
+
+void assert_metric_families_equivalent(int source, int destination,
+                                       const seastar::sstring& name) {
+    const auto& source_value_map = smi::get_value_map(source);
+    const auto& destination_value_map = smi::get_value_map(destination);
+
+    BOOST_REQUIRE(source_value_map.contains(name));
+    BOOST_REQUIRE(destination_value_map.contains(name));
+
+    const auto& source_family = source_value_map.at(name);
+    const auto& destination_family = destination_value_map.at(name);
+    for (const auto& [labels, source_metric]: source_family) {
+        auto replica_iter = destination_family.find(labels);
+        BOOST_REQUIRE(replica_iter != destination_family.end());
+        
+        const auto& replica_metric = replica_iter->second;
+        BOOST_REQUIRE(source_metric->get_id() == replica_metric->get_id());
+
+        auto source_current_value = source_metric->get_function()().i();
+        auto replica_current_value = replica_metric->get_function()().i();
+        BOOST_REQUIRE(source_current_value == replica_current_value);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(replicate_metrics_test) {
+    int foo_handle = sm::default_handle();
+    sm::metric_groups foo(foo_handle);
+    foo.add_group("a", {
+        sm::make_gauge(
+            "gauge",
+            [] { return 0; })});
+
+    int bar_handle = sm::default_handle() + 1;
+    int baz_handle = sm::default_handle() + 2;
+    sm::replicate_metric_families(foo_handle, {
+            {"a_gauge", bar_handle},
+            {"a_gauge", baz_handle}
+    }).get();
+
+    assert_metric_families_equivalent(foo_handle, bar_handle, "a_gauge");
+    assert_metric_families_equivalent(foo_handle, baz_handle, "a_gauge");
+}
+
+SEASTAR_THREAD_TEST_CASE(replicate_same_metric_test) {
+    int foo_handle = sm::default_handle();
+
+    sm::metric_groups foo(foo_handle);
+    foo.add_group("a", {
+        sm::make_gauge(
+            "x",
+            [] { return 0; },
+            sm::description("a_x_description"),
+            {sm::label("id")("1")}),
+        sm::make_gauge(
+            "x",
+            [] { return 0; },
+            sm::description("a_x_description"),
+            {sm::label("id")("2")}),
+        sm::make_gauge(
+            "y",
+            [] { return 0; },
+            sm::description("a_y_description"),
+            {sm::label("id")("1")}),
+    });
+
+    int bar_handle = sm::default_handle() + 1;
+    sm::metric_groups bar(bar_handle);
+
+    // Test that subsequent attempts to replicate the same metric
+    // family are ignored.
+    sm::replicate_metric_families(foo_handle, {{"a_x", bar_handle}}).get();
+    assert_metric_families_equivalent(foo_handle, bar_handle, "a_x");
+    sm::replicate_metric_families(foo_handle, {{"a_x", bar_handle}}).get();
+    assert_metric_families_equivalent(foo_handle, bar_handle, "a_x");
+
+
+    // Ensure that when the set of replicated metric families is changed
+    // the replicas that are not in the new set are removed.
+    sm::replicate_metric_families(foo_handle, {{"a_y", bar_handle}}).get();
+    assert_metric_families_equivalent(foo_handle, bar_handle, "a_y");
+
+    BOOST_REQUIRE(metric_family_exists(bar_handle, "a_y"));
+}


### PR DESCRIPTION
### What?
This PR extends the seastar metrics sub-system with the ability to replicate metric families across different internal metric
implementation (for more context see #25).

### Why?
Our use case for this change is to expose a selection of internal seastar metrics on the new metrics endpoint, "/public_metrics".
Seastar metrics are registered on the default metric implementation (not the one driving "/public_metrics"), so we need a way
of registering certain seastar metrics on an internal implementation of our choice. The alternative to what this PR proposes
is to make the data required for the desired metrics available via seastar public APIs, but that's more intrusive and the registration
would lead to some involved code in Redpanda.

### How?
Each `metrics::impl` (internal implementation) object stores a set of specifications for metric families that need replicating. When that set is first initialized, we replicate all currently registered metric families that match one of the specs to the specified internal implementation. Whenever a new metric is registered or removed we check if the family it belongs to is replicated and, in that case
mirror the operation on the replicated family.

The call to replicate a set of metric families would look like below. It tells seastar to replicate the "io_queue_total_bytes" metrics family that's registered with the default implementation on the metrics implementation identified by handle 1.
```
seastar::metrics::replicate_metric_families(0, {{1, "io_queue_total_bytes"}}).get();
```
[force push](https://github.com/redpanda-data/seastar/compare/c745dceba585dd4b3af93a741cb997dfb2040422..622a8ab96b9ceac11a07b47a49b800bba0f6dd9a):
* added unit tests for metric replication
* changed internal storage of replicated metrics to `std::unordered_map` in order to reflect the
fact that each replicated family should have on destination only
* ignore metrics that are already replicated

[force push](https://github.com/redpanda-data/seastar/compare/622a8ab96b9ceac11a07b47a49b800bba0f6dd9a..942f1d32e641518201682f4a92a0d6dd7c70fdb0):
* update comment for `set_metric_families_to_replicate`

[force push](https://github.com/redpanda-data/seastar/compare/942f1d32e641518201682f4a92a0d6dd7c70fdb0..e5d7dee772ccf8c6a348034e884cd4369e52267b):
* enable multiple destinations for the same metric family
* add a unit test for the above
* lift `get_local_impl` higher up in the call chain to minimise lookups