### PR TITLE
Use the same internal implementation after clear

### DIFF
--- a/include/seastar/core/metrics.hh
+++ b/include/seastar/core/metrics.hh
@@ -394,6 +394,7 @@ public:
     virtual metric_groups_def& add_metric(group_name_type name, const metric_definition& md) = 0;
     virtual metric_groups_def& add_group(group_name_type name, const std::initializer_list<metric_definition>& l) = 0;
     virtual metric_groups_def& add_group(group_name_type name, const std::vector<metric_definition>& l) = 0;
+    virtual int get_handle() const = 0;
 };
 
 instance_id_type shard();

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -182,6 +182,7 @@ public:
     metric_groups_impl& add_metric(group_name_type name, const metric_definition& md);
     metric_groups_impl& add_group(group_name_type name, const std::initializer_list<metric_definition>& l);
     metric_groups_impl& add_group(group_name_type name, const std::vector<metric_definition>& l);
+    int get_handle() const;
 };
 
 class impl;

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -40,7 +40,8 @@ metric_groups::metric_groups(int handle) noexcept : _impl(impl::create_metric_gr
 }
 
 void metric_groups::clear() {
-    _impl = impl::create_metric_groups();
+    const auto current_handle = _impl->get_handle();
+    _impl = impl::create_metric_groups(current_handle);
 }
 
 metric_groups::metric_groups(std::initializer_list<metric_group_definition> mg, int handle) : _impl(impl::create_metric_groups(handle)) {

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -237,6 +237,10 @@ metric_groups_impl& metric_groups_impl::add_group(group_name_type name, const st
     return *this;
 }
 
+int metric_groups_impl::get_handle() const {
+    return _handle;
+}
+
 bool metric_id::operator<(
         const metric_id& id2) const {
     return as_tuple() < id2.as_tuple();


### PR DESCRIPTION
This PR updates the 'metric_groups::clear` method to retain the same metrics implementation after the call.