### PR TITLE
util/conversion: support IEC prefix like "Ki"

### DIFF
--- a/include/seastar/util/conversions.hh
+++ b/include/seastar/util/conversions.hh
@@ -29,13 +29,19 @@ namespace seastar {
 
 // Convert a string to a memory size, allowing binary SI
 // suffixes (intentionally, even though SI suffixes are
-// decimal, to follow existing usage).
+// decimal, to follow existing usage). A string matched
+// by following BNF is accetped:
+//
+// memory_size ::= <digit>+ <suffix>? "i"? "B"?
+// suffix ::= ("k" | "K" | "M" | "G" | "T")
+//
+// for instance:
 //
 // "5" -> 5
 // "4k" -> (4 << 10)
-// "8M" -> (8 << 20)
-// "7G" -> (7 << 30)
-// "1T" -> (1 << 40)
+// "8Mi" -> (8 << 20)
+// "7GB" -> (7 << 30)
+// "1TiB" -> (1 << 40)
 // anything else: exception
 size_t parse_memory_size(std::string_view s);
 

--- a/include/seastar/util/conversions.hh
+++ b/include/seastar/util/conversions.hh
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <cstdlib>
-#include <string>
+#include <string_view>
 #include <vector>
 
 namespace seastar {
@@ -37,9 +37,9 @@ namespace seastar {
 // "7G" -> (7 << 30)
 // "1T" -> (1 << 40)
 // anything else: exception
-size_t parse_memory_size(std::string s);
+size_t parse_memory_size(std::string_view s);
 
-static inline std::vector<char> string2vector(std::string str) {
+static inline std::vector<char> string2vector(std::string_view str) {
     auto v = std::vector<char>(str.begin(), str.end());
     v.push_back('\0');
     return v;

--- a/src/util/conversions.cc
+++ b/src/util/conversions.cc
@@ -24,23 +24,36 @@
 
 #include <seastar/util/conversions.hh>
 #include <seastar/core/print.hh>
+#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cctype>
 
 namespace seastar {
 
+static constexpr struct {
+    std::string_view suffix;
+    unsigned power;
+} suffixes[] = {
+    {"k", 10},
+    {"K", 10},
+    {"M", 20},
+    {"G", 30},
+    {"T", 40},
+};
+
 size_t parse_memory_size(std::string_view s) {
+    for (std::string_view unit : {"i", "iB", "B"}) {
+        if (boost::algorithm::ends_with(s, unit)) {
+            s.remove_suffix(unit.size());
+            break;
+        }
+    }
     size_t factor = 1;
-    if (s.size()) {
-        auto c = s[s.size() - 1];
-        if (!isdigit(c)) {
-            static std::string suffixes = "kMGT";
-            auto pos = suffixes.find(c);
-            if (pos == suffixes.npos) {
-                throw std::runtime_error(format("Cannot parse memory size '{}'", s));
-            }
-            factor <<= (pos + 1) * 10;
-            s = s.substr(0, s.size() - 1);
+    for (auto [suffix, power] : suffixes) {
+        if (boost::algorithm::ends_with(s, suffix)) {
+            factor <<= power;
+            s.remove_suffix(suffix.size());
+            break;
         }
     }
     return boost::lexical_cast<size_t>(s) * factor;

--- a/src/util/conversions.cc
+++ b/src/util/conversions.cc
@@ -29,7 +29,7 @@
 
 namespace seastar {
 
-size_t parse_memory_size(std::string s) {
+size_t parse_memory_size(std::string_view s) {
     size_t factor = 1;
     if (s.size()) {
         auto c = s[s.size() - 1];


### PR DESCRIPTION
this is the first prerequisite of a better fix of https://github.com/redpanda-data/redpanda/issues/352 -- to teach Seastar to understand IEC prefixes. and then, we can probably revert https://github.com/redpanda-data/redpanda/pull/602 if rpk always has a strong dependency on the same version of the redpanda daemon executable.

the change has been merged in upstream. see https://github.com/scylladb/seastar/commit/23a57b8155d9146b9829eb05b1985280c19750d5