### PR TITLE
Create the seastar_memory logger in all builds

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -85,6 +85,11 @@ void* internal::allocate_aligned_buffer_impl(size_t size, size_t align) {
 
 namespace memory {
 
+// We always create the logger object for memory disagnostics, even in
+// in SEASTAR_DEFAULT_ALLOCATOR builds, though it only logs when the
+// seastar allocator is enabled.
+seastar::logger seastar_memory_logger("seastar_memory");
+
 static thread_local int abort_on_alloc_failure_suppressed = 0;
 
 disable_abort_on_alloc_failure_temporarily::disable_abort_on_alloc_failure_temporarily() {
@@ -181,8 +186,6 @@ namespace seastar {
 using allocation_site_ptr = const allocation_site*;
 
 namespace memory {
-
-seastar::logger seastar_memory_logger("seastar_memory");
 
 [[gnu::unused]]
 static allocation_site_ptr get_allocation_site();


### PR DESCRIPTION
Currently the seastar_memory logger is only created when
SEASTAR_DEFAULT_ALLOCATOR is undefined, i.e., when the seastar
allocator is being used. That makes sense in that this logger is only
ever used to emit diagnostics by the seastar allocator.

However, it means that seastar applications which try to adjust the
seastar logger level on the command line will fail because this logger
does not exist. So you have to handle this command line argument
differnetly in release and debug builds.

A more forgiving approach is to allow setting the level of this logger
regardless of the build type. After all, it is valid to set the level of a
loggeer that happens not to log anything for a particular run. This only
takes this a bit further since the logger will *never* log anything in
debug builds.

To do this, we simply move the logger object out of the conditionally
compiled region.