### PR TITLE
scheduling_group: expose usage statistics

### DIFF
--- a/include/seastar/core/scheduling.hh
+++ b/include/seastar/core/scheduling.hh
@@ -293,6 +293,13 @@ public:
     friend unsigned internal::scheduling_group_index(scheduling_group sg) noexcept;
     friend scheduling_group internal::scheduling_group_from_index(unsigned index) noexcept;
 
+    struct stats {
+        sched_clock::duration runtime;
+        sched_clock::duration waittime;
+        sched_clock::duration starvetime;
+    };
+    stats get_stats() const noexcept;
+
     template<typename SpecificValType, typename Mapper, typename Reducer, typename Initial>
     SEASTAR_CONCEPT( requires requires(SpecificValType specific_val, Mapper mapper, Reducer reducer, Initial initial) {
         {reducer(initial, mapper(specific_val))} -> std::convertible_to<Initial>;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4512,6 +4512,16 @@ scheduling_group::set_shares(float shares) noexcept {
     engine()._task_queues[_id]->set_shares(shares);
 }
 
+scheduling_group::stats
+scheduling_group::get_stats() const noexcept {
+    const auto * const tq = engine()._task_queues[_id].get();
+    return {
+        .runtime = tq->_runtime,
+        .waittime = tq->_waittime,
+        .starvetime = tq->_starvetime
+    };
+}
+
 future<scheduling_group>
 create_scheduling_group(sstring name, float shares) noexcept {
     auto aid = allocate_scheduling_group_id();


### PR DESCRIPTION
This PR extends the public interface of scheduling_group to expose
usage statistics (e.g. runtime).