### PR TITLE
Add allocation failure metric to memory metrics

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -234,16 +234,19 @@ class statistics {
     size_t _free_memory;
     uint64_t _reclaims;
     uint64_t _large_allocs;
+    uint64_t _failed_allocs;
 
     uint64_t _foreign_mallocs;
     uint64_t _foreign_frees;
     uint64_t _foreign_cross_frees;
 private:
     statistics(uint64_t mallocs, uint64_t frees, uint64_t cross_cpu_frees,
-            uint64_t total_memory, uint64_t free_memory, uint64_t reclaims, uint64_t large_allocs,
+            uint64_t total_memory, uint64_t free_memory, uint64_t reclaims,
+            uint64_t large_allocs, uint64_t failed_allocs,
             uint64_t foreign_mallocs, uint64_t foreign_frees, uint64_t foreign_cross_frees)
         : _mallocs(mallocs), _frees(frees), _cross_cpu_frees(cross_cpu_frees)
-        , _total_memory(total_memory), _free_memory(free_memory), _reclaims(reclaims), _large_allocs(large_allocs)
+        , _total_memory(total_memory), _free_memory(free_memory), _reclaims(reclaims)
+        , _large_allocs(large_allocs), _failed_allocs(failed_allocs)
         , _foreign_mallocs(foreign_mallocs), _foreign_frees(foreign_frees)
         , _foreign_cross_frees(foreign_cross_frees) {}
 public:
@@ -266,6 +269,9 @@ public:
     uint64_t reclaims() const { return _reclaims; }
     /// Number of allocations which violated the large allocation threshold
     uint64_t large_allocations() const { return _large_allocs; }
+    /// Number of allocations which failed, i.e., where the required memory could not be obtained
+    /// even after reclaim was attempted
+    uint64_t failed_allocations() const { return _failed_allocs; }
     /// Number of foreign allocations
     uint64_t foreign_mallocs() const { return _foreign_mallocs; }
     /// Number of foreign frees

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -2271,7 +2271,7 @@ void configure(std::vector<resource::memory> m, bool mbind, std::optional<std::s
 }
 
 statistics stats() {
-    return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0};
+    return statistics{0, 0, 0, 1 << 30, 1 << 30, 0, 0, 0, 0, 0, 0};
 }
 
 size_t free_memory() {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2277,7 +2277,8 @@ void reactor::register_metrics() {
             sm::make_current_bytes("free_memory", [] { return memory::stats().free_memory(); }, sm::description("Free memory size in bytes")),
             sm::make_current_bytes("total_memory", [] { return memory::stats().total_memory(); }, sm::description("Total memory size in bytes")),
             sm::make_current_bytes("allocated_memory", [] { return memory::stats().allocated_memory(); }, sm::description("Allocated memory size in bytes")),
-            sm::make_counter("reclaims_operations", [] { return memory::stats().reclaims(); }, sm::description("Total reclaims operations"))
+            sm::make_counter("reclaims_operations", [] { return memory::stats().reclaims(); }, sm::description("Total reclaims operations")),
+            sm::make_counter("malloc_failed", [] { return memory::stats().failed_allocations(); }, sm::description("Total count of failed memory allocations"))
     });
 
     _metric_groups.add_group("reactor", {

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -19,6 +19,7 @@
  * Copyright (C) 2015 Cloudius Systems, Ltd.
  */
 
+#include <boost/test/tools/old/interface.hpp>
 #include <seastar/testing/test_case.hh>
 #include <seastar/core/memory.hh>
 #include <seastar/core/smp.hh>
@@ -212,11 +213,7 @@ SEASTAR_TEST_CASE(test_bad_alloc_throws) {
 
     // test that new throws
     stats = seastar::memory::stats();
-    try {
-        sink = operator new(size);
-        BOOST_TEST_FAIL("operator new did not throw");
-    } catch (std::bad_alloc&) {
-    }
+    BOOST_REQUIRE_THROW(sink = operator new(size), std::bad_alloc);
     BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge malloc returns null

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -206,23 +206,35 @@ SEASTAR_TEST_CASE(test_bad_alloc_throws) {
     [[gnu::unused]]
     void * volatile sink;
 
+    auto failed_allocs = [&stats]() {
+        return seastar::memory::stats().failed_allocations() - stats.failed_allocations();
+    };
+
     // test that new throws
+    stats = seastar::memory::stats();
     try {
         sink = operator new(size);
         BOOST_TEST_FAIL("operator new did not throw");
     } catch (std::bad_alloc&) {
     }
+    BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge malloc returns null
+    stats = seastar::memory::stats();
     BOOST_REQUIRE_EQUAL(malloc(size), nullptr);
+    BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge realloc on nullptr returns null
+    stats = seastar::memory::stats();
     BOOST_REQUIRE_EQUAL(realloc(nullptr, size), nullptr);
+    BOOST_CHECK_EQUAL(failed_allocs(), 1);
 
     // test that huge realloc on an existing ptr returns null
+    stats = seastar::memory::stats();
     void *p = malloc(1);
     BOOST_REQUIRE(p);
     BOOST_REQUIRE_EQUAL(realloc(p, size), nullptr);
+    BOOST_CHECK_EQUAL(failed_allocs(), 1);
     free(p);
 
     return make_ready_future<>();

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -25,6 +25,8 @@
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/memory_diagnostics.hh>
 
+#include <memory>
+#include <new>
 #include <vector>
 #include <future>
 #include <iostream>
@@ -191,6 +193,37 @@ SEASTAR_TEST_CASE(test_realloc_nullptr) {
     BOOST_REQUIRE(p1 != nullptr);
     free(p0);
     free(p1);
+
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_bad_alloc_throws) {
+    // test that a large allocation throws bad_alloc
+    auto stats = seastar::memory::stats();
+
+    size_t size = stats.total_memory() * 2; // cannot be satisfied
+
+    [[gnu::unused]]
+    void * volatile sink;
+
+    // test that new throws
+    try {
+        sink = operator new(size);
+        BOOST_TEST_FAIL("operator new did not throw");
+    } catch (std::bad_alloc&) {
+    }
+
+    // test that huge malloc returns null
+    BOOST_REQUIRE_EQUAL(malloc(size), nullptr);
+
+    // test that huge realloc on nullptr returns null
+    BOOST_REQUIRE_EQUAL(realloc(nullptr, size), nullptr);
+
+    // test that huge realloc on an existing ptr returns null
+    void *p = malloc(1);
+    BOOST_REQUIRE(p);
+    BOOST_REQUIRE_EQUAL(realloc(p, size), nullptr);
+    free(p);
 
     return make_ready_future<>();
 }


### PR DESCRIPTION
This metric counts the number of times an allocation request
could not be satisfied even after reclaim, and a nullptr/bad_alloc
was returned/thrown.

