### PR TITLE
dns: Handle TCP mode connect failure

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -671,6 +671,10 @@ private:
                         tcp.indata.trim_front(len);
                         return len;
                     }
+                    if (!tcp.socket) {
+                        errno = ENOTCONN;
+                        return -1;
+                    }
                     if (!tcp.in) {
                         tcp.in = tcp.socket.input();
                     }
@@ -808,6 +812,11 @@ private:
                 if (e.typ == type::tcp && !(e.avail & POLLOUT)) {
                     dns_log.trace("Send already pending {}", fd);
                     errno = EWOULDBLOCK;
+                    return -1;
+                }
+
+                if (!e.tcp.socket) {
+                    errno = ENOTCONN;
                     return -1;
                 }
 


### PR DESCRIPTION
Fixes #1244

Iff a TCP mode ARES socket connection fails, we don't get a socket in the socket struct for the virtual fd. As the connect function cannot fail at this point (engine::connect completion), we can only set all poll flags and wake up the select emulation we are running.

Here we expect to detect the error in the upcoming sendv call, we however do not check this field being fully initialized -> crash.

Simple fix,. just verify field, if not inited, return ENOTCONN.

(cherry picked from commit 1d9f3306bb04fba7337550037b2140c1600139f2)