### PR TITLE
Fixed concurrent socket access in `dns_resolve`

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -809,7 +809,7 @@ private:
 
             for (;;) {
                 // check if we're already writing.
-                if (e.typ == type::tcp && !(e.avail & POLLOUT)) {
+                if (!(e.avail & POLLOUT)) {
                     dns_log.trace("Send already pending {}", fd);
                     errno = EWOULDBLOCK;
                     return -1;


### PR DESCRIPTION

The problem with DNS queries is caused by the fact that the UDP socket
is used concurrently i.e. write is scheduled while the other one is
pending.

DNS queries are based on c-ares library. The library is initialized with
a set of functions (callbacks) that are called whenever there is a need
to send, receive, create socket, connect or close.

Fixed processing of send requests leading to assertion being triggered
in reactor.

The fix involves checking if send is already pending and if so returning
an error. The error returned from send callback will instruct c-ares
library to retry the query.