### PR TITLE
[v22.3.x] httpd: revert `Connection` header handling changes

### DIFF
--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -144,21 +144,6 @@ struct request {
         return listener_idx;
     }
 
-    bool should_keep_alive() const {
-        if (_version == "0.9") {
-            return false;
-        }
-
-        // TODO: handle HTTP/2.0 when it releases
-
-        auto it = _headers.find("Connection");
-        if (_version == "1.0") {
-            return it != _headers.end()
-                 && case_insensitive_cmp()(it->second, "keep-alive");
-        } else { // HTTP/1.1
-            return it == _headers.end() || !case_insensitive_cmp()(it->second, "close");
-        }
-    }
 };
 
 } // namespace httpd

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -425,21 +425,40 @@ void connection::set_headers(reply& resp) {
 
 future<bool> connection::generate_reply(std::unique_ptr<request> req) {
     auto resp = std::make_unique<reply>();
-    resp->set_version(req->_version);
-    set_headers(*resp);
-    bool keep_alive = req->should_keep_alive();
-    if (keep_alive && req->_version == "1.0") {
-        resp->_headers["Connection"] = "Keep-Alive";
+    bool conn_keep_alive = false;
+    bool conn_close = false;
+    auto it = req->_headers.find("Connection");
+    if (it != req->_headers.end()) {
+        if (request::case_insensitive_cmp()(it->second, "keep-alive")) {
+            conn_keep_alive = true;
+        } else if (request::case_insensitive_cmp()(it->second, "close")) {
+            conn_close = true;
+        }
     }
+    bool should_close;
+    // TODO: Handle HTTP/2.0 when it releases
+    resp->set_version(req->_version);
 
+    if (req->_version == "1.0") {
+        if (conn_keep_alive) {
+            resp->_headers["Connection"] = "Keep-Alive";
+        }
+        should_close = !conn_keep_alive;
+    } else if (req->_version == "1.1") {
+        should_close = conn_close;
+    } else {
+        // HTTP/0.9 goes here
+        should_close = true;
+    }
     sstring url = set_query_param(*req.get());
     sstring version = req->_version;
+    set_headers(*resp);
     return _server._routes.handle(url, std::move(req), std::move(resp)).
     // Caller guarantees enough room
-    then([this, keep_alive , version = std::move(version)](std::unique_ptr<reply> rep) {
+    then([this, should_close, version = std::move(version)](std::unique_ptr<reply> rep) {
         rep->set_version(version).done();
         this->_replies.push(std::move(rep));
-        return make_ready_future<bool>(!keep_alive);
+        return make_ready_future<bool>(should_close);
     });
 }
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -429,9 +429,9 @@ future<bool> connection::generate_reply(std::unique_ptr<request> req) {
     bool conn_close = false;
     auto it = req->_headers.find("Connection");
     if (it != req->_headers.end()) {
-        if (request::case_insensitive_cmp()(it->second, "keep-alive")) {
+        if (it->second == "Keep-Alive") {
             conn_keep_alive = true;
-        } else if (request::case_insensitive_cmp()(it->second, "close")) {
+        } else if (it->second == "Close") {
             conn_close = true;
         }
     }


### PR DESCRIPTION
These changes were added between our v22.2.x and v22.3.x seastar branches, and cause dropped connections from `urllib` clients that use Connection: close, including ansible.

This doesn't exactly fix whatever the bug is, but reverts to the old behavior where "close" headers from urllib were ignored, which worked in practice.

Related: https://github.com/redpanda-data/redpanda/issues/8020