### PR TITLE
semaphore: assert no outstanding units when moved

### DIFF
--- a/include/seastar/core/semaphore.hh
+++ b/include/seastar/core/semaphore.hh
@@ -30,6 +30,10 @@
 #include <seastar/core/expiring_fifo.hh>
 #include <seastar/core/timed_out_error.hh>
 
+#ifdef SEASTAR_DEBUG
+#define SEASTAR_SEMAPHORE_DEBUG
+#endif
+
 namespace seastar {
 
 /// \addtogroup fiber-module
@@ -84,6 +88,9 @@ struct named_semaphore_exception_factory {
     broken_named_semaphore broken() const noexcept;
 };
 
+template<typename ExceptionFactory, typename Clock>
+class semaphore_units;
+
 /// \brief Counted resource guard.
 ///
 /// This is a standard computer science semaphore, adapted
@@ -112,6 +119,24 @@ public:
 private:
     ssize_t _count;
     std::exception_ptr _ex;
+#ifdef SEASTAR_SEMAPHORE_DEBUG
+    size_t _outstanding_units = 0;
+
+    void assert_not_held() const noexcept {
+        assert(!_outstanding_units && "semaphore moved with outstanding units");
+    }
+    void add_outstanding_units(size_t n) {
+        _outstanding_units += n;
+    }
+    void sub_outstanding_units(size_t n) {
+        _outstanding_units -= n;
+    }
+#else   // SEASTAR_SEMAPHORE_DEBUG
+    void assert_not_held() const noexcept {}
+    void add_outstanding_units(size_t) {}
+    void sub_outstanding_units(size_t) {}
+#endif  // SEASTAR_SEMAPHORE_DEBUG
+
     struct entry {
         promise<> pr;
         size_t nr;
@@ -134,6 +159,8 @@ private:
     bool may_proceed(size_t nr) const noexcept {
         return has_available_units(nr) && _wait_list.empty();
     }
+
+    friend class semaphore_units<ExceptionFactory, Clock>;
 public:
     /// Returns the maximum number of units the semaphore counter can hold
     static constexpr size_t max_counter() noexcept {
@@ -157,6 +184,27 @@ public:
     {
         static_assert(std::is_nothrow_move_constructible_v<expiry_handler>);
     }
+
+    basic_semaphore(const basic_semaphore&) = delete;
+    basic_semaphore(basic_semaphore&& o) noexcept
+        : _count(std::exchange(o._count, 0))
+        , _ex(std::move(o._ex))
+        , _wait_list(std::move(o._wait_list))
+    {
+        o.assert_not_held();
+    }
+
+    basic_semaphore& operator=(basic_semaphore&& o) noexcept {
+        if (this != &o) {
+            o.assert_not_held();
+            assert_not_held();
+            _count = std::exchange(o._count, 0);
+            _ex = std::move(o._ex);
+            _wait_list = std::move(o._wait_list);
+        }
+        return *this;
+    }
+
     /// Waits until at least a specific number of units are available in the
     /// counter, and reduces the counter by that amount of units.
     ///
@@ -336,9 +384,11 @@ class semaphore_units {
     basic_semaphore<ExceptionFactory, Clock>* _sem;
     size_t _n;
 
-    semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {}
+    semaphore_units(basic_semaphore<ExceptionFactory, Clock>* sem, size_t n) noexcept : _sem(sem), _n(n) {
+        _sem->add_outstanding_units(n);
+    }
 public:
-    semaphore_units() noexcept : semaphore_units(nullptr, 0) {}
+    semaphore_units() noexcept : _sem(nullptr), _n(0) {}
     semaphore_units(basic_semaphore<ExceptionFactory, Clock>& sem, size_t n) noexcept : semaphore_units(&sem, n) {}
     semaphore_units(semaphore_units&& o) noexcept : _sem(o._sem), _n(std::exchange(o._n, 0)) {
     }
@@ -363,12 +413,14 @@ public:
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
+        _sem->sub_outstanding_units(units);
         _sem->signal(units);
         return _n;
     }
     /// Return ownership of all units. The semaphore will be signaled by the number of units returned.
     void return_all() noexcept {
         if (_n) {
+            _sem->sub_outstanding_units(_n);
             _sem->signal(_n);
             _n = 0;
         }
@@ -377,6 +429,7 @@ public:
     ///
     /// \return the number of units held
     size_t release() noexcept {
+        _sem->sub_outstanding_units(_n);
         return std::exchange(_n, 0);
     }
     /// Splits this instance into a \ref semaphore_units object holding the specified amount of units.
@@ -392,6 +445,11 @@ public:
             throw std::invalid_argument("Cannot take more units than those protected by the semaphore");
         }
         _n -= units;
+        // `units` are split into a new `semaphore_units` object.
+        // since none are returned to the semaphore we subtract the
+        // outstanding units here to balance their eventual addition by the
+        // `semaphore_units` ctor.
+        _sem->sub_outstanding_units(units);
         return semaphore_units(_sem, units);
     }
     /// The inverse of split(), in which the units held by the specified \ref semaphore_units
@@ -401,7 +459,9 @@ public:
     /// \return the updated semaphore_units object
     void adopt(semaphore_units&& other) noexcept {
         assert(other._sem == _sem);
-        _n += other.release();
+        auto o = other.release();
+        _sem->add_outstanding_units(o);
+        _n += o;
     }
 
     /// Returns the number of units held

--- a/tests/unit/semaphore_test.cc
+++ b/tests/unit/semaphore_test.cc
@@ -239,17 +239,19 @@ SEASTAR_TEST_CASE(test_with_semaphore) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_semaphore_units_splitting) {
-    auto sm = semaphore(2);
-    auto units = get_units(sm, 2, 1min).get0();
+    auto sm = semaphore(3);
+    auto units = get_units(sm, 3, 1min).get0();
     {
-        BOOST_REQUIRE_EQUAL(units.count(), 2);
+        BOOST_REQUIRE_EQUAL(units.count(), 3);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
         auto split = units.split(1);
         BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
+        BOOST_REQUIRE_EQUAL(units.count(), 2);
+        BOOST_REQUIRE_EQUAL(split.count(), 1);
     }
     BOOST_REQUIRE_EQUAL(sm.available_units(), 1);
     units.~semaphore_units();
-    units = get_units(sm, 2, 1min).get0();
+    units = get_units(sm, 3, 1min).get0();
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
     BOOST_REQUIRE_THROW(units.split(10), std::invalid_argument);
     BOOST_REQUIRE_EQUAL(sm.available_units(), 0);
@@ -328,4 +330,15 @@ SEASTAR_THREAD_TEST_CASE(test_named_semaphore_timeout) {
     } catch (...) {
         BOOST_FAIL("Expected an instance of named_semaphore_timed_out with proper semaphore name");
     }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_semaphore_move_with_outstanding_units) {
+    auto sem0 = semaphore(1);
+    auto sem = std::make_unique<semaphore>(std::move(sem0));
+    auto units = std::make_unique<semaphore_units<>>(get_units(*sem, 1).get());
+    BOOST_REQUIRE_EQUAL(sem->current(), 0);
+    auto sem1 = std::move(sem);
+    BOOST_REQUIRE_EQUAL(sem1->current(), 0);
+    units.reset();
+    BOOST_REQUIRE_EQUAL(sem1->current(), 1);
 }


### PR DESCRIPTION
semaphore_units keeps a pointer to the semaphore
soe if the semaphore is moved and/or destroyed
destroying the sempahore_units will caused
use-after-move or use-after-free.

This change adds _outstanding_units counter member to basic_semaphore and manages it in semaphore_units. semaphore move constructor then asserts that
o._outstanding_units == 0 when moved.

Add a unit test to semaphore_test to cover this case.

Refs #1323

Cherry-picked from [3061b2](https://github.com/scylladb/seastar/commit/3061b2f53a9a89596786763db03e3ae44398d33c)

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>