### PR TITLE
iostream: always flush _fd in do_flush

### DIFF
--- a/include/seastar/core/iostream-impl.hh
+++ b/include/seastar/core/iostream-impl.hh
@@ -423,7 +423,7 @@ future<> output_stream<CharType>::do_flush() noexcept {
             return _fd.flush();
         });
     } else {
-        return make_ready_future<>();
+        return _fd.flush();
     }
 }
 


### PR DESCRIPTION
Previously, do_flush would skip calling flush
on the underlying _fd if _end==0.

If the semantics of flush are "flush data, all the way to the underlying file" then this is incorrect, because in the slow_write path we may set _end=0 and call through to put() immediately: this leaves output_stream in a state where the next call to flush() does nothing, but the underlying data_sink (for example file_data_sink_impl) has a writebehind operation in flight.

If the output stream is then dropped, we may crash when the underlying fd's write behind op tries
to complete.

One can work around this by closing the output_stream instead of just flushing it, but this doesn't fit if the caller wants to keep their file object open beyond the lifetime of the output stream.