### PR TITLE
abort_source: move-assign operator: call base class unlink

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -80,9 +80,7 @@ public:
         subscription& operator=(subscription&& other) noexcept(std::is_nothrow_move_assignable<subscription_callback_type>::value) {
             if (this != &other) {
                 _target = std::move(other._target);
-                if (is_linked()) {
-                    subscription_list_type::node_algorithms::unlink(this_ptr());
-                }
+                unlink();
                 subscription_list_type::node_algorithms::swap_nodes(other.this_ptr(), this_ptr());
             }
             return *this;

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -99,3 +99,17 @@ SEASTAR_TEST_CASE(test_negative_sleep_abortable) {
         return sleep_abortable(-10s, as);
     });
 }
+
+SEASTAR_TEST_CASE(test_destroy_with_moved_subscriptions) {
+    auto as = std::make_unique<abort_source>();
+    int aborted = 0;
+    auto sub1 = as->subscribe([&] () noexcept { ++aborted; });
+    auto sub2 = std::move(sub1);
+    optimized_optional<abort_source::subscription> sub3;
+    sub3 = std::move(sub2);
+    auto sub4 = as->subscribe([&] () noexcept { ++aborted; });
+    sub4 = std::move(sub3);
+    as.reset();
+    BOOST_REQUIRE_EQUAL(aborted, 0);
+    return make_ready_future<>();
+}


### PR DESCRIPTION
calling `node_algorithms::unlink(this_ptr())` with an engaged subscription results in use-after-free that is reproduced by the added unit test.

Fixes #1336

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>