### PR TITLE
[v22.2.x] Backport pr1233: aio_general_context: flush: provide 1 second grace for retries

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -26,6 +26,7 @@
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/read_first_line.hh>
+
 #include <chrono>
 #include <sys/poll.h>
 #include <sys/syscall.h>
@@ -306,7 +307,9 @@ void aio_general_context::queue(linux_abi::iocb* iocb) {
 
 size_t aio_general_context::flush() {
     auto begin = iocbs.get();
-    auto retried = last;
+    using clock = std::chrono::steady_clock;
+    constexpr clock::time_point no_time_point = clock::time_point(clock::duration(0));
+    auto retry_until = no_time_point;
     while (begin != last) {
         auto r = io_submit(io_context, last - begin, begin);
         if (__builtin_expect(r > 0, true)) {
@@ -314,11 +317,12 @@ size_t aio_general_context::flush() {
             continue;
         }
         // errno == EAGAIN is expected here. We don't explicitly assert that
-        // since the assert below requires that some progress will be
-        // made, preventing an endless loop for any reason.
-        if (need_preempt()) {
-            assert(retried != begin);
-            retried = begin;
+        // since the assert below prevents an endless loop for any reason.
+        if (retry_until == no_time_point) {
+            // allow retrying for 1 second
+            retry_until = clock::now() + 1s;
+        } else {
+            assert(clock::now() < retry_until);
         }
     }
     auto nr = last - iocbs.get();


### PR DESCRIPTION
The existing assert that was introduced in
528762adbaf2c6dde857957b920606378959e8fb
is too harsh.  It will fail on the first retry
failure after `needs_preeempt` returned true.

This lead to the following crash:
```
scylla: ./seastar/src/core/reactor_backend.cc:286: size_t seastar::aio_general_context::flush(): Assertion `retried != begin' failed.
```

Decoded backtrace:
```
seastar::aio_general_context::flush() at ./build/release/seastar/./seastar/src/core/reactor_backend.cc:286
 (inlined by) seastar::reactor_backend_aio::wait_and_process_events(__sigset_t const*) at ./build/release/seastar/./seastar/src/core/reactor_backend.cc:489
seastar::reactor::sleep() at ./build/release/seastar/./seastar/src/core/reactor.cc:3041
 (inlined by) seastar::reactor::do_run() at ./build/release/seastar/./seastar/src/core/reactor.cc:3007
seastar::reactor::run() at ./build/release/seastar/./seastar/src/core/reactor.cc:2839
seastar::app_template::run_deprecated(int, char**, std::function&&) at ./build/release/seastar/./seastar/src/core/app-template.cc:228
seastar::app_template::run(int, char**, std::function ()>&&) at ./build/release/seastar/./seastar/src/core/app-template.cc:128
main at ./main.cc:492
```

This change uses the std::chrono::steady_clock to allow flush to complete within 1 second of the first `io_submit` failure.

Note that the seastar lowres_clock is unsuitable for this purpose since it won't advance if the reactor has no chance to run.

Fixes #975

Test: unit(release)

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>
(cherry picked from commit 1fb42e2776239341935efd7700336ec5eb9bc253)