### PR TITLE
http: rename http client logger

### DIFF
--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -30,7 +30,7 @@
 #include <seastar/http/internal/content_source.hh>
 
 namespace seastar {
-logger http_log("http");
+logger http_log("seastar_http_client");
 namespace http {
 namespace experimental {
 


### PR DESCRIPTION
Redpanda uses this logger name for its http client and we choose to change the logger name in Seastar to avoid duplicate logger registration exceptions.