### PR TITLE
Sampling heap profiler 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,3 +6,7 @@ under the BSD license.
 
 This work contains software from the DPDK project (http://dpdk.org), licensed
 under the BSD license.  The software is under the dpdk/ directory.
+
+This work contains software from the Android Open Source Project,
+licensed under the Apache2 license.
+The software is in the include/seastar/util/sampler.hh file.

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "seastar/util/backtrace.hh"
+#include "seastar/util/sampler.hh"
 #include <seastar/core/resource.hh>
 #include <seastar/core/bitops.hh>
 #include <new>
@@ -156,10 +157,9 @@ public:
 // Can be nested, in which case the profiling is re-enabled when all
 // the objects go out of scope.
 class disable_backtrace_temporarily {
-    bool _old;
+    sampler::disable_sampling_temporarily _disable_sampling;
 public:
     disable_backtrace_temporarily();
-    ~disable_backtrace_temporarily();
 };
 
 enum class reclaiming_result {
@@ -386,7 +386,9 @@ public:
 /// Describes an allocation location in the code.  The location is identified by
 /// its backtrace. One allocation_site can represent many allocations at the
 /// same location. `count` and `size` represent the cumulative sum of all
-/// allocations at the location.
+/// allocations at the location. Note the size represents an extrapolated size and
+/// not the sampled one, i.e.: when looking at the total size of all allocation
+/// sites it will approximate the total memory usage
 struct allocation_site {
     mutable size_t count = 0; // number of live objects allocated at backtrace.
     mutable size_t size = 0; // amount of bytes in live objects allocated at backtrace.
@@ -407,36 +409,49 @@ struct allocation_site {
     }
 };
 
-/// If memory profiling is on returns the current memory live set
-std::vector<allocation_site> memory_profile();
+/// If memory sampling is on returns the current sampled memory live set
+///
+/// If there is tracked allocations (because heap profiling was on earlier)
+/// these will still be returned if heap profiling is now off
+std::vector<allocation_site> sampled_memory_profile();
 
-/// Copies the current set of allocation_sites in the output parameter
+/// Copies the current sampled set of allocation_sites in the output parameter
 /// (up to size of output vector) Returns amount of copied elements. Useful if
 /// one wants to avoid allocating an output vector (e.g.: under OOM conditions)
-size_t memory_profile(std::vector<allocation_site>&);
+size_t sampled_memory_profile(std::vector<allocation_site>&);
 
-/// Enable heap profiling
+/// Enable sampled heap profiling by setting a sample rate
+/// disable heap profiling by setting the sample rate to 0
 ///
 /// In order to use heap profiling you have to define
 /// `SEASTAR_HEAPPROF`.
+///
+/// Use \ref sampled_memory_profile for API access to profiling data
+///
+/// Note: Changing the sampling rate is currently not supported.
+/// Re-enabling heap profiling with a different sample rate to previous is fine
+/// to do if and only if all allocations are freeed before heap profiling is
+/// turned back on.
 ///
 /// For an example script that makes use of the heap profiling data
 /// see [scylla-gdb.py] (https://github.com/scylladb/scylla/blob/e1b22b6a4c56b4f1d0adf65d1a11db4bcb51fe7d/scylla-gdb.py#L1439)
 /// This script can generate either textual representation of the data,
 /// or a zoomable flame graph ([flame graph generation instructions](https://github.com/scylladb/scylla/wiki/Seastar-heap-profiler),
 /// [example flame graph](https://user-images.githubusercontent.com/1389273/72920437-f0cf8a80-3d51-11ea-92f0-f3dbeb698871.png)).
-void set_heap_profiling_enabled(bool);
+void set_heap_profiling_sampling_rate(size_t);
 
-/// Checks whether heap profiling is currently enabled
-bool get_heap_profiling_enabled();
+/// Returns the current heap profiling sampling rate (0 means off)
+size_t get_heap_profiling_sample_rate();
 
 /// Enable heap profiling for the duration of the scope.
 ///
+/// Note: Nesting different sample rates is currently not supported.
+///
 /// For more information about heap profiling see
-/// \ref set_heap_profiling_enabled().
+/// \ref set_heap_profiling_sampling_rate().
 class scoped_heap_profiling {
 public:
-    scoped_heap_profiling() noexcept;
+    scoped_heap_profiling(size_t) noexcept;
     ~scoped_heap_profiling();
 };
 

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -390,8 +390,13 @@ public:
 struct allocation_site {
     mutable size_t count = 0; // number of live objects allocated at backtrace.
     mutable size_t size = 0; // amount of bytes in live objects allocated at backtrace.
-    mutable const allocation_site* next = nullptr; // TODO: remove
     simple_backtrace backtrace; // call site for this allocation
+
+    // All allocation sites are linked to each other. This can be used for easy
+    // iteration across them in gdb scripts where it's difficult to work with
+    // the C++ data structures.
+    mutable const allocation_site* next = nullptr; // next allocation site in the chain
+    mutable const allocation_site* prev = nullptr; // previous allocation site in the chain
 
     bool operator==(const allocation_site& o) const {
         return backtrace == o.backtrace;

--- a/include/seastar/core/reactor_config.hh
+++ b/include/seastar/core/reactor_config.hh
@@ -147,8 +147,12 @@ struct reactor_options : public program_options::option_group {
     program_options::value<unsigned> max_networking_io_control_blocks;
     /// \brief Enable seastar heap profiling.
     ///
+    /// Allocations will be sampled every N bytes on average. Zero means off.
+    ///
+    /// Default: 0
+    ///
     /// \note Unused when seastar was compiled without heap profiling support.
-    program_options::value<> heapprof;
+    program_options::value<unsigned> heapprof;
     /// Ignore SIGINT (for gdb).
     program_options::value<> no_handle_interrupt;
 

--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -75,8 +75,8 @@ private:
 private:
     size_t calculate_hash() const noexcept;
 public:
-    simple_backtrace(char delimeter = ' ') noexcept : _delimeter(delimeter) {}
-    simple_backtrace(vector_type f, char delimeter = ' ') noexcept : _frames(std::move(f)), _delimeter(delimeter) {}
+    simple_backtrace(vector_type f, char delimeter = ' ') noexcept : _frames(std::move(f)), _hash(calculate_hash()), _delimeter(delimeter) {}
+    simple_backtrace(char delimeter = ' ') noexcept : simple_backtrace({}, delimeter) {}
 
     size_t hash() const noexcept { return _hash; }
     char delimeter() const noexcept { return _delimeter; }

--- a/include/seastar/util/sampler.hh
+++ b/include/seastar/util/sampler.hh
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_PROFILING_MEMORY_SAMPLER_H_
+#define SRC_PROFILING_MEMORY_SAMPLER_H_
+
+#include <stdint.h>
+
+#include <atomic>
+#include <random>
+
+#include "perfetto/ext/base/utils.h"
+
+namespace perfetto {
+namespace profiling {
+
+constexpr uint64_t kSamplerSeed = 1;
+
+std::default_random_engine& GetGlobalRandomEngineLocked();
+
+// Poisson sampler for memory allocations. We apply sampling individually to
+// each byte. The whole allocation gets accounted as often as the number of
+// sampled bytes it contains.
+//
+// The algorithm is inspired by the Chromium sampling algorithm at
+// https://cs.chromium.org/search/?q=f:cc+symbol:AllocatorShimLogAlloc+package:%5Echromium$&type=cs
+// Googlers: see go/chrome-shp for more details.
+//
+// NB: not thread-safe, requires external synchronization.
+class Sampler {
+ public:
+  void SetSamplingInterval(uint64_t sampling_interval) {
+    sampling_interval_ = sampling_interval;
+    sampling_rate_ = 1.0 / static_cast<double>(sampling_interval_);
+    interval_to_next_sample_ = NextSampleInterval();
+  }
+
+  // Returns number of bytes that should be be attributed to the sample.
+  // If returned size is 0, the allocation should not be sampled.
+  //
+  // Due to how the poission sampling works, some samples should be accounted
+  // multiple times.
+  size_t SampleSize(size_t alloc_sz) {
+    if (PERFETTO_UNLIKELY(alloc_sz >= sampling_interval_))
+      return alloc_sz;
+    return static_cast<size_t>(sampling_interval_ * NumberOfSamples(alloc_sz));
+  }
+
+  uint64_t sampling_interval() const { return sampling_interval_; }
+
+ private:
+  int64_t NextSampleInterval() {
+    std::exponential_distribution<double> dist(sampling_rate_);
+    int64_t next = static_cast<int64_t>(dist(GetGlobalRandomEngineLocked()));
+    // We approximate the geometric distribution using an exponential
+    // distribution.
+    // We need to add 1 because that gives us the number of failures before
+    // the next success, while our interval includes the next success.
+    return next + 1;
+  }
+
+  // Returns number of times a sample should be accounted. Due to how the
+  // poission sampling works, some samples should be accounted multiple times.
+  size_t NumberOfSamples(size_t alloc_sz) {
+    interval_to_next_sample_ -= alloc_sz;
+    size_t num_samples = 0;
+    while (PERFETTO_UNLIKELY(interval_to_next_sample_ <= 0)) {
+      interval_to_next_sample_ += NextSampleInterval();
+      ++num_samples;
+    }
+    return num_samples;
+  }
+
+  uint64_t sampling_interval_;
+  double sampling_rate_;
+  int64_t interval_to_next_sample_;
+};
+
+}  // namespace profiling
+}  // namespace perfetto
+
+#endif  // SRC_PROFILING_MEMORY_SAMPLER_H_

--- a/include/seastar/util/sampler.hh
+++ b/include/seastar/util/sampler.hh
@@ -14,82 +14,145 @@
  * limitations under the License.
  */
 
-#ifndef SRC_PROFILING_MEMORY_SAMPLER_H_
-#define SRC_PROFILING_MEMORY_SAMPLER_H_
+// This file has been originally been imported from:
+// https://cs.android.com/android/platform/superproject/+/013901367630d3ec71c9f2bb3f3077bd11585301:external/perfetto/src/profiling/memory/sampler.h
 
-#include <stdint.h>
+//
+// The code has been modified as follows:
+//
+//  - Integrated into seastar and adapted to coding style
+//  - Right now we don't account for samples multiple times (in case we have
+//  multiple loops of drawing from the exp distribution). The reason is that
+//  in our memory sampler we would have to store the weight in addition to the
+//  alloation site ptr as on free we need to know how much a sample accounted
+//  for. Hence, for now we simply always use the sampling interval.
+//  - Sampler can be turned "off" with a 0 sampling rate
+//  - The fast path is more optimized (as a consequence of the first point)
+//  - Provide a way to temporarily pause sampling
+//
+// Changes Copyright (C) 2023 ScyllaDB
 
-#include <atomic>
+#pragma once
+
 #include <random>
 
-#include "perfetto/ext/base/utils.h"
+// See also: https://perfetto.dev/docs/design-docs/heapprofd-sampling for more
+// background of how the sampler works
 
-namespace perfetto {
-namespace profiling {
-
-constexpr uint64_t kSamplerSeed = 1;
-
-std::default_random_engine& GetGlobalRandomEngineLocked();
-
-// Poisson sampler for memory allocations. We apply sampling individually to
-// each byte. The whole allocation gets accounted as often as the number of
-// sampled bytes it contains.
-//
-// The algorithm is inspired by the Chromium sampling algorithm at
-// https://cs.chromium.org/search/?q=f:cc+symbol:AllocatorShimLogAlloc+package:%5Echromium$&type=cs
-// Googlers: see go/chrome-shp for more details.
-//
-// NB: not thread-safe, requires external synchronization.
-class Sampler {
- public:
-  void SetSamplingInterval(uint64_t sampling_interval) {
-    sampling_interval_ = sampling_interval;
-    sampling_rate_ = 1.0 / static_cast<double>(sampling_interval_);
-    interval_to_next_sample_ = NextSampleInterval();
-  }
-
-  // Returns number of bytes that should be be attributed to the sample.
-  // If returned size is 0, the allocation should not be sampled.
-  //
-  // Due to how the poission sampling works, some samples should be accounted
-  // multiple times.
-  size_t SampleSize(size_t alloc_sz) {
-    if (PERFETTO_UNLIKELY(alloc_sz >= sampling_interval_))
-      return alloc_sz;
-    return static_cast<size_t>(sampling_interval_ * NumberOfSamples(alloc_sz));
-  }
-
-  uint64_t sampling_interval() const { return sampling_interval_; }
-
- private:
-  int64_t NextSampleInterval() {
-    std::exponential_distribution<double> dist(sampling_rate_);
-    int64_t next = static_cast<int64_t>(dist(GetGlobalRandomEngineLocked()));
-    // We approximate the geometric distribution using an exponential
-    // distribution.
-    // We need to add 1 because that gives us the number of failures before
-    // the next success, while our interval includes the next success.
-    return next + 1;
-  }
-
-  // Returns number of times a sample should be accounted. Due to how the
-  // poission sampling works, some samples should be accounted multiple times.
-  size_t NumberOfSamples(size_t alloc_sz) {
-    interval_to_next_sample_ -= alloc_sz;
-    size_t num_samples = 0;
-    while (PERFETTO_UNLIKELY(interval_to_next_sample_ <= 0)) {
-      interval_to_next_sample_ += NextSampleInterval();
-      ++num_samples;
+class sampler {
+public:
+    sampler() : random_gen(rd_device()) {
+        set_sampling_interval(0);
     }
-    return num_samples;
-  }
+    /// Sets the sampling interval in bytes. Setting it to 0 means to never sample
+    void set_sampling_interval(uint64_t sampling_interval) {
+        sampling_interval_ = sampling_interval;
+        if (sampling_interval_ == 0) {
+            // Set the interval very large. This means in practice we will
+            // likely never get this below zero and hence it's unlikely we will
+            // ever have to run the reset path with sampling off
+            interval_to_next_sample_ = std::numeric_limits<int64_t>::max();
+            return;
+        }
+        sampling_rate_ = 1.0 / static_cast<double>(sampling_interval_);
+        interval_to_next_sample_ = next_sampling_interval();
+    }
+    /// Returns true if this allocation of size `alloc_size` should be sampled
+    bool should_sample(size_t alloc_size) {
+        // We need to check the sampling_interval as 0 means off. Also we need
+        // to check whether this allocation has brought the interval
+        // below/to 0. We chose to check the interval_to_next_sample first. If
+        // heap profiling is compiled in it's likely we are using it as well.
+        // Hence, lets do the interval decrement and check first and only check
+        // whether sampling is off after.
+        interval_to_next_sample_ -= alloc_size;
+        if (interval_to_next_sample_ > 0) {
+            return false;
+        }
+        reset_interval_to_next_sample(alloc_size);
+        return sampling_interval_ != 0;
+    }
 
-  uint64_t sampling_interval_;
-  double sampling_rate_;
-  int64_t interval_to_next_sample_;
+    uint64_t sampling_interval() const { return sampling_interval_; }
+
+    /// How much should an allocation of size `allocation_size` count for
+    size_t sample_size(size_t allocation_size) const {
+        return std::max(allocation_size, sampling_interval_);
+    }
+
+    /// RAII class to temporarily pause sampling
+    struct disable_sampling_temporarily {
+        disable_sampling_temporarily() = default;
+        disable_sampling_temporarily(sampler& sampler)
+        : sampler_(&sampler)
+        , previous_sampling_interval_(sampler_->sampling_interval_)
+        , previous_sampling_rate_(sampler_->sampling_rate_)
+        , previous_interval_to_next_sample_(sampler_->interval_to_next_sample_) {
+            sampler_->set_sampling_interval(0);
+        }
+
+        ~disable_sampling_temporarily() {
+            if (sampler_) {
+                sampler_->sampling_interval_ = previous_sampling_interval_;
+                sampler_->sampling_rate_ = previous_sampling_rate_;
+                sampler_->interval_to_next_sample_ = previous_interval_to_next_sample_;
+            }
+        }
+
+    private:
+        sampler* sampler_ = nullptr;
+        uint64_t previous_sampling_interval_ = 0; // sampling interval before pausing
+        double previous_sampling_rate_ = 0; // sampling rate before pausing
+        int64_t previous_interval_to_next_sample_ = 0; // interval to next sample before pausing
+    };
+
+    /// Pauses sampling temporarily until the returned object is destroyed. This
+    /// is more efficient and statisically more correct than doing a back and
+    /// fourth of set_sampling_interval(0) and set_sampling_interval(RATE). The
+    /// reason is that that would reset the interval to the next sample and
+    /// force a reevaluation of the exponential distribution. This method avoids
+    /// that.
+    disable_sampling_temporarily pause_sampling() {
+        return disable_sampling_temporarily(*this);
+    }
+
+private:
+    /// Resets interval_to_next_sample_ by repeatedly drawing from the
+    /// exponential distribution given an allocation of size `alloc_size`
+    /// breached the current interval
+    void reset_interval_to_next_sample(size_t alloc_size)
+    {
+        if (sampling_interval_ == 0) { // sampling is off
+            interval_to_next_sample_ = std::numeric_limits<int64_t>::max();
+        }
+        else {
+            // Large allocations we will just consider in whole. This avoids
+            // having to sample the distribution too many times if a large alloc
+            // took us very negative we just add the alloc size back on
+            if (alloc_size > sampling_interval_) {
+                interval_to_next_sample_ += alloc_size;
+            }
+            else {
+                while (interval_to_next_sample_ <= 0) {
+                    interval_to_next_sample_ += next_sampling_interval();
+                }
+            }
+        }
+    }
+
+    int64_t next_sampling_interval() {
+        std::exponential_distribution<double> dist(sampling_rate_);
+        int64_t next = static_cast<int64_t>(dist(random_gen));
+        // We approximate the geometric distribution using an exponential
+        // distribution.
+        // We need to add 1 because that gives us the number of failures before
+        // the next success, while our interval includes the next success.
+        return next + 1;
+    }
+
+    uint64_t sampling_interval_; // Sample every N bytes ; 0 means off
+    double sampling_rate_; // 1 / sampling_interval_ ; used by the exp distribution
+    int64_t interval_to_next_sample_; // Next time we are going to take a sample
+    std::random_device rd_device;
+    std::mt19937_64 random_gen;
 };
-
-}  // namespace profiling
-}  // namespace perfetto
-
-#endif  // SRC_PROFILING_MEMORY_SAMPLER_H_

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -155,36 +155,6 @@ __thread volatile int critical_alloc_section = 0;
 #include <numaif.h>
 #endif
 
-namespace seastar {
-
-struct allocation_site {
-    mutable size_t count = 0; // number of live objects allocated at backtrace.
-    mutable size_t size = 0; // amount of bytes in live objects allocated at backtrace.
-    mutable const allocation_site* next = nullptr;
-    saved_backtrace backtrace;
-
-    bool operator==(const allocation_site& o) const {
-        return backtrace == o.backtrace;
-    }
-
-    bool operator!=(const allocation_site& o) const {
-        return !(*this == o);
-    }
-};
-
-}
-
-namespace std {
-
-template<>
-struct hash<seastar::allocation_site> {
-    size_t operator()(const seastar::allocation_site& bi) const {
-        return std::hash<seastar::saved_backtrace>()(bi.backtrace);
-    }
-};
-
-}
-
 #if FMT_VERSION >= 90000
 namespace seastar::memory {
 struct human_readable_value;
@@ -194,7 +164,7 @@ template <> struct fmt::formatter<struct seastar::memory::human_readable_value> 
 
 namespace seastar {
 
-using allocation_site_ptr = const allocation_site*;
+using allocation_site_ptr = const memory::allocation_site*;
 
 namespace memory {
 
@@ -473,16 +443,20 @@ public:
 static constexpr size_t max_small_allocation
     = small_pool::idx_to_size(small_pool_array::nr_small_pools - 1);
 
-constexpr size_t object_size_with_alloc_site(size_t size) {
+constexpr size_t object_size_with_alloc_site(size_t size, bool is_sampled) {
+    (void) is_sampled;
 #ifdef SEASTAR_HEAPPROF
     // For page-aligned sizes, allocation_site* lives in page::alloc_site, not with the object.
     static_assert(is_page_aligned(max_small_allocation), "assuming that max_small_allocation is page aligned so that we"
             " don't need to add allocation_site_ptr to objects of size close to it");
-    size_t next_page_aligned_size = next_page_aligned(size);
-    if (next_page_aligned_size - size > sizeof(allocation_site_ptr)) {
-        size += sizeof(allocation_site_ptr);
-    } else {
-        return next_page_aligned_size;
+    if (is_sampled)
+    {
+        size_t next_page_aligned_size = next_page_aligned(size);
+        if (next_page_aligned_size - size > sizeof(allocation_site_ptr)) {
+            size += sizeof(allocation_site_ptr);
+        } else {
+            return next_page_aligned_size;
+        }
     }
 #endif
     return size;
@@ -490,12 +464,14 @@ constexpr size_t object_size_with_alloc_site(size_t size) {
 
 #ifdef SEASTAR_HEAPPROF
 // Ensure that object_size_with_alloc_site() does not exceed max_small_allocation
-static_assert(object_size_with_alloc_site(max_small_allocation) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - 1) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) + 1) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr)) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 1) == max_small_allocation - 1, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 2) == max_small_allocation - 2, "");
+static_assert(object_size_with_alloc_site(max_small_allocation, true) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - 1, true) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) + 1, true) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr), true) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 1, true) == max_small_allocation - 1, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 2, true) == max_small_allocation - 2, "");
+// Sanity check that non-sampled doesn't change size
+static_assert(object_size_with_alloc_site(8, false) == 8, "");
 #endif
 
 struct cross_cpu_free_item {
@@ -570,6 +546,8 @@ struct cpu_pages {
     void replace_memory_backing(allocate_system_memory_fn alloc_sys_mem);
     void check_large_allocation(size_t size);
     void warn_large_allocation(size_t size);
+    allocation_site_ptr add_alloc_site(size_t allocated_size);
+    void remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_size);
     memory::memory_layout memory_layout();
     ~cpu_pages();
 };
@@ -596,6 +574,10 @@ void set_heap_profiling_enabled(bool enable) {
     get_cpu_mem().collect_backtrace = enable;
 }
 
+bool get_heap_profiling_enabled() {
+    return get_cpu_mem().collect_backtrace;
+}
+
 static thread_local int64_t scoped_heap_profiling_embed_count = 0;
 
 scoped_heap_profiling::scoped_heap_profiling() noexcept {
@@ -614,6 +596,11 @@ scoped_heap_profiling::~scoped_heap_profiling() {
 void set_heap_profiling_enabled(bool enable) {
     seastar_logger.warn("Seastar compiled without heap profiling support, heap profiler not supported;"
             " compile with the Seastar_HEAP_PROFILING=ON CMake option to add heap profiling support");
+}
+
+bool get_heap_profiling_enabled() {
+    // don't log here, called on all paths
+    return false;
 }
 
 scoped_heap_profiling::scoped_heap_profiling() noexcept {
@@ -763,11 +750,10 @@ cpu_pages::allocate_large_and_trim(unsigned n_pages) {
     span->span_size = span_end->span_size = span_size;
     span->pool = nullptr;
 #ifdef SEASTAR_HEAPPROF
-    auto alloc_site = get_allocation_site();
-    span->alloc_site = alloc_site;
-    if (alloc_site) {
-        ++alloc_site->count;
-        alloc_site->size += span->span_size * page_size;
+    if (get_heap_profiling_enabled())
+    {
+        auto alloc_site = add_alloc_site(span->span_size * page_size);
+        span->alloc_site = alloc_site;
     }
 #endif
     maybe_reclaim();
@@ -779,6 +765,29 @@ cpu_pages::warn_large_allocation(size_t size) {
     alloc_stats::increment_local(alloc_stats::types::large_allocs);
     seastar_memory_logger.warn("oversized allocation: {} bytes. This is non-fatal, but could lead to latency and/or fragmentation issues. Please report: at {}", size, current_backtrace());
     large_allocation_warning_threshold *= 1.618; // prevent spam
+}
+
+allocation_site_ptr
+cpu_pages::add_alloc_site(size_t allocated_size) {
+    allocation_site_ptr alloc_site = get_allocation_site();
+    if (alloc_site) {
+        ++alloc_site->count;
+        alloc_site->size += allocated_size;
+    }
+
+    return alloc_site;
+}
+
+void 
+cpu_pages::remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_size) {
+    if (alloc_site) {
+        --alloc_site->count;
+        alloc_site->size -= deallocated_size;
+        if (alloc_site->count == 0)
+        {
+            asu.alloc_sites.erase(*alloc_site);
+        }
+    }
 }
 
 void
@@ -812,9 +821,9 @@ disable_backtrace_temporarily::~disable_backtrace_temporarily() {
 }
 
 static
-saved_backtrace get_backtrace() noexcept {
+simple_backtrace get_backtrace() noexcept {
     disable_backtrace_temporarily dbt;
-    return current_backtrace();
+    return current_backtrace_tasklocal();
 }
 
 static
@@ -854,15 +863,11 @@ cpu_pages::allocate_small(unsigned size) {
     assert(size <= pool.object_size());
     auto ptr = pool.allocate();
 #ifdef SEASTAR_HEAPPROF
-    if (!ptr) {
-        return nullptr;
+    if (get_heap_profiling_enabled() && ptr)
+    {
+        auto alloc_site = add_alloc_site(pool.object_size());
+        new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
     }
-    allocation_site_ptr alloc_site = get_allocation_site();
-    if (alloc_site) {
-        ++alloc_site->count;
-        alloc_site->size += pool.object_size();
-    }
-    new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
 #endif
     return ptr;
 }
@@ -871,10 +876,10 @@ void cpu_pages::free_large(void* ptr) {
     pageidx idx = (reinterpret_cast<char*>(ptr) - mem()) / page_size;
     page* span = &pages[idx];
 #ifdef SEASTAR_HEAPPROF
-    auto alloc_site = span->alloc_site;
-    if (alloc_site) {
-        --alloc_site->count;
-        alloc_site->size -= span->span_size * page_size;
+    if (get_heap_profiling_enabled())
+    {
+        auto alloc_site = span->alloc_site;
+        remove_alloc_site(alloc_site, span->span_size * page_size);
     }
 #endif
     free_span(idx, span->span_size);
@@ -885,9 +890,12 @@ size_t cpu_pages::object_size(void* ptr) {
     if (span->pool) {
         auto s = span->pool->object_size();
 #ifdef SEASTAR_HEAPPROF
-        // We must not allow the object to be extended onto the allocation_site_ptr field.
-        if (!span->pool->objects_page_aligned()) {
-            s -= sizeof(allocation_site_ptr);
+        if (get_heap_profiling_enabled())
+        {
+            // We must not allow the object to be extended onto the allocation_site_ptr field.
+            if (!span->pool->objects_page_aligned()) {
+                s -= sizeof(allocation_site_ptr);
+            }
         }
 #endif
         return s;
@@ -930,10 +938,10 @@ void cpu_pages::free(void* ptr) {
     if (span->pool) {
         small_pool& pool = *span->pool;
 #ifdef SEASTAR_HEAPPROF
-        allocation_site_ptr alloc_site = pool.alloc_site_holder(ptr);
-        if (alloc_site) {
-            --alloc_site->count;
-            alloc_site->size -= pool.object_size();
+        if (get_heap_profiling_enabled())
+        {
+            allocation_site_ptr alloc_site = pool.alloc_site_holder(ptr);
+            remove_alloc_site(alloc_site, pool.object_size());
         }
 #endif
         pool.deallocate(ptr);
@@ -948,13 +956,16 @@ void cpu_pages::free(void* ptr, size_t size) {
         size = sizeof(free_object);
     }
     if (size <= max_small_allocation) {
-        size = object_size_with_alloc_site(size);
+        size = object_size_with_alloc_site(size, get_heap_profiling_enabled());
         auto pool = &small_pools[small_pool::size_to_idx(size)];
 #ifdef SEASTAR_HEAPPROF
-        allocation_site_ptr alloc_site = pool->alloc_site_holder(ptr);
-        if (alloc_site) {
-            --alloc_site->count;
-            alloc_site->size -= pool->object_size();
+        if (get_heap_profiling_enabled())
+        {
+            allocation_site_ptr alloc_site = pool->alloc_site_holder(ptr);
+            if (alloc_site) {
+                --alloc_site->count;
+                alloc_site->size -= pool->object_size();
+            }
         }
 #endif
         pool->deallocate(ptr);
@@ -997,10 +1008,13 @@ void cpu_pages::shrink(void* ptr, size_t new_size) {
         return;
     }
 #ifdef SEASTAR_HEAPPROF
-    auto alloc_site = span->alloc_site;
-    if (alloc_site) {
-        alloc_site->size -= span->span_size * page_size;
-        alloc_site->size += new_size_pages * page_size;
+    if (get_heap_profiling_enabled())
+    {
+        auto alloc_site = span->alloc_site;
+        if (alloc_site) {
+            alloc_site->size -= span->span_size * page_size;
+            alloc_site->size += new_size_pages * page_size;
+        }
     }
 #endif
     span->span_size = new_size_pages;
@@ -1400,7 +1414,7 @@ void* allocate(size_t size) {
     }
     void* ptr;
     if (size <= max_small_allocation) {
-        size = object_size_with_alloc_site(size);
+        size = object_size_with_alloc_site(size, get_heap_profiling_enabled());
         ptr = get_cpu_mem().allocate_small(size);
     } else {
         ptr = allocate_large(size);
@@ -1433,7 +1447,7 @@ void* allocate_aligned(size_t align, size_t size) {
     if (size <= max_small_allocation && align <= page_size) {
         // Our small allocator only guarantees alignment for power-of-two
         // allocations which are not larger than a page.
-        size = 1 << log2ceil(object_size_with_alloc_site(size));
+        size = 1 << log2ceil(object_size_with_alloc_site(size, get_heap_profiling_enabled()));
         ptr = get_cpu_mem().allocate_small(size);
     } else {
         ptr = allocate_large_aligned(align, size);
@@ -1471,7 +1485,7 @@ void free_aligned(void* obj, size_t align, size_t size) {
     }
     if (size <= max_small_allocation && align <= page_size) {
         // Same adjustment as allocate_aligned()
-        size = 1 << log2ceil(object_size_with_alloc_site(size));
+        size = 1 << log2ceil(object_size_with_alloc_site(size, get_heap_profiling_enabled()));
     }
     free(obj, size);
 }
@@ -1852,6 +1866,18 @@ static bool try_trigger_error_injector() {
     } catch (...) {
         return true;
     }
+}
+
+std::vector<allocation_site> memory_profile() {
+    disable_backtrace_temporarily dbt;
+    std::vector<allocation_site> ret(get_cpu_mem().asu.alloc_sites.begin(), get_cpu_mem().asu.alloc_sites.end());
+    return ret;
+}
+
+size_t memory_profile(std::vector<allocation_site>& output) {
+    auto to_copy = std::min(output.size(), get_cpu_mem().asu.alloc_sites.size());
+    std::copy_n(get_cpu_mem().asu.alloc_sites.begin(), to_copy, output.begin());
+    return to_copy;
 }
 
 }
@@ -2265,6 +2291,18 @@ disable_backtrace_temporarily::~disable_backtrace_temporarily() {
 
 void set_heap_profiling_enabled(bool enabled) {
     seastar_logger.warn("Seastar compiled with default allocator, heap profiler not supported");
+}
+
+bool get_heap_profiling_enabled() {
+    return false;
+}
+
+std::vector<allocation_site> memory_profile() {
+    return {};
+}
+
+size_t memory_profile(std::vector<allocation_site>&) { 
+    return 0; 
 }
 
 scoped_heap_profiling::scoped_heap_profiling() noexcept {

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -871,10 +871,18 @@ allocation_site_ptr get_allocation_site() {
     if (!cpu_mem.is_initialized() || !cpu_mem.heap_prof_sampler.sampling_interval()) {
         return nullptr;
     }
-    // TODO: limit size of alloc_sites
     disable_backtrace_temporarily dbt;
     allocation_site new_alloc_site;
     new_alloc_site.backtrace = get_backtrace();
+    if (cpu_mem.asu.alloc_sites.size() >= 1000
+        && cpu_mem.asu.alloc_sites.find(new_alloc_site) == cpu_mem.asu.alloc_sites.end())
+    {
+        // Drop sample for now. Could do something smarter like dropping a
+        // current one at random but needs more work in remove_alloc_site as we
+        // might then have allocations for which the allocsite is no longer
+        // alive
+        return nullptr;
+    }
     auto insert_result = cpu_mem.asu.alloc_sites.insert(std::move(new_alloc_site));
     allocation_site_ptr alloc_site = &*insert_result.first;
     if (insert_result.second) {

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -377,14 +377,21 @@ class small_pool {
     unsigned _min_free;
     unsigned _max_free;
     unsigned _pages_in_use = 0;
+    // Flag to indicate whether this pool stores sampled allocations.
+    // When freeing small allocations this flag is checked to see whether an
+    // allocation site pointer is part of the object and the allocation needs
+    // removal from the allocation_site tracking
+    bool _sampled_pool = false;
     page_list _span_list;
     static constexpr unsigned idx_frac_bits = 2;
 public:
-    explicit small_pool(unsigned object_size) noexcept;
+    explicit small_pool(unsigned object_size, bool is_sampled) noexcept;
     ~small_pool();
     void* allocate();
     void deallocate(void* object);
     unsigned object_size() const { return _object_size; }
+    /// See _sampled_pool
+    bool is_sampled_pool() const { return _sampled_pool; }
     bool objects_page_aligned() const { return is_page_aligned(_object_size); }
     static constexpr unsigned size_to_idx(unsigned size);
     static constexpr unsigned idx_to_size(unsigned idx);
@@ -420,6 +427,7 @@ small_pool::size_to_idx(unsigned size) {
             + ((size - 1) >> (log2floor(size) - idx_frac_bits));
 }
 
+template<bool sampled> // tag the pools in this array as sampled, see small_pool._sampled_pool
 class small_pool_array {
 public:
     static constexpr unsigned nr_small_pools = small_pool::size_to_idx(4 * page_size) + 1;
@@ -428,7 +436,7 @@ private:
         small_pool a[nr_small_pools];
         u() {
             for (unsigned i = 0; i < nr_small_pools; ++i) {
-                new (&a[i]) small_pool(small_pool::idx_to_size(i));
+                new (&a[i]) small_pool(small_pool::idx_to_size(i), sampled);
             }
         }
         ~u() {
@@ -441,37 +449,29 @@ public:
 };
 
 static constexpr size_t max_small_allocation
-    = small_pool::idx_to_size(small_pool_array::nr_small_pools - 1);
+    = small_pool::idx_to_size(small_pool_array<false>::nr_small_pools - 1);
 
-constexpr size_t object_size_with_alloc_site(size_t size, bool is_sampled) {
-    (void) is_sampled;
 #ifdef SEASTAR_HEAPPROF
+constexpr size_t object_size_with_alloc_site(size_t size) {
     // For page-aligned sizes, allocation_site* lives in page::alloc_site, not with the object.
     static_assert(is_page_aligned(max_small_allocation), "assuming that max_small_allocation is page aligned so that we"
             " don't need to add allocation_site_ptr to objects of size close to it");
-    if (is_sampled)
-    {
-        size_t next_page_aligned_size = next_page_aligned(size);
-        if (next_page_aligned_size - size > sizeof(allocation_site_ptr)) {
-            size += sizeof(allocation_site_ptr);
-        } else {
-            return next_page_aligned_size;
-        }
+    size_t next_page_aligned_size = next_page_aligned(size);
+    if (next_page_aligned_size - size > sizeof(allocation_site_ptr)) {
+        size += sizeof(allocation_site_ptr);
+    } else {
+        return next_page_aligned_size;
     }
-#endif
     return size;
 }
 
-#ifdef SEASTAR_HEAPPROF
 // Ensure that object_size_with_alloc_site() does not exceed max_small_allocation
-static_assert(object_size_with_alloc_site(max_small_allocation, true) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - 1, true) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) + 1, true) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr), true) == max_small_allocation, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 1, true) == max_small_allocation - 1, "");
-static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 2, true) == max_small_allocation - 2, "");
-// Sanity check that non-sampled doesn't change size
-static_assert(object_size_with_alloc_site(8, false) == 8, "");
+static_assert(object_size_with_alloc_site(max_small_allocation) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - 1) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) + 1) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr)) == max_small_allocation, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 1) == max_small_allocation - 1, "");
+static_assert(object_size_with_alloc_site(max_small_allocation - sizeof(allocation_site_ptr) - 2) == max_small_allocation - 2, "");
 #endif
 
 struct cross_cpu_free_item {
@@ -491,7 +491,8 @@ struct cpu_pages {
     std::vector<reclaimer*> reclaimers;
     static constexpr unsigned nr_span_lists = 32;
     page_list free_spans[nr_span_lists];  // contains aligned spans with span_size == 2^idx
-    small_pool_array small_pools;
+    small_pool_array<false> small_pools;
+    small_pool_array<true> sampled_small_pools;
     alignas(seastar::cache_line_size) std::atomic<cross_cpu_free_item*> xcpu_freelist;
     static std::atomic<unsigned> cpu_id_gen;
     static cpu_pages* all_cpus[max_cpus];
@@ -523,7 +524,6 @@ struct cpu_pages {
     void free_span(pageidx start, uint32_t nr_pages);
     void free_span_no_merge(pageidx start, uint32_t nr_pages);
     void free_span_unaligned(pageidx start, uint32_t nr_pages);
-    void* allocate_small(unsigned size);
     void free(void* ptr);
     void free(void* ptr, size_t size);
     static bool try_foreign_free(void* ptr);
@@ -755,6 +755,9 @@ cpu_pages::allocate_large_and_trim(unsigned n_pages) {
         auto alloc_site = add_alloc_site(span->span_size * page_size);
         span->alloc_site = alloc_site;
     }
+    else {
+        span->alloc_site = nullptr;
+    }
 #endif
     maybe_reclaim();
     return mem() + span_idx * page_size;
@@ -772,7 +775,7 @@ cpu_pages::add_alloc_site(size_t allocated_size) {
     allocation_site_ptr alloc_site = get_allocation_site();
     if (alloc_site) {
         ++alloc_site->count;
-        alloc_site->size += allocated_size;
+        alloc_site->size += std::max(sampler.sampling_interval(), allocated_size);
     }
 
     return alloc_site;
@@ -782,9 +785,22 @@ void
 cpu_pages::remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_size) {
     if (alloc_site) {
         --alloc_site->count;
-        alloc_site->size -= deallocated_size;
+        alloc_site->size -= std::max(sampler.sampling_interval(), deallocated_size);
         if (alloc_site->count == 0)
         {
+            if (alloc_site->prev)
+            {
+                alloc_site->prev->next = alloc_site->next;
+            }
+            if (alloc_site->next)
+            {
+                alloc_site->next->prev = alloc_site->prev;
+            }
+            if (alloc_site_list_head == alloc_site)
+            {
+                alloc_site_list_head = alloc_site->next;
+            }
+
             asu.alloc_sites.erase(*alloc_site);
         }
     }
@@ -831,6 +847,7 @@ allocation_site_ptr get_allocation_site() {
     if (!cpu_mem.is_initialized() || !cpu_mem.collect_backtrace) {
         return nullptr;
     }
+    // TODO: limit size of alloc_sites
     disable_backtrace_temporarily dbt;
     allocation_site new_alloc_site;
     new_alloc_site.backtrace = get_backtrace();
@@ -838,6 +855,10 @@ allocation_site_ptr get_allocation_site() {
     allocation_site_ptr alloc_site = &*insert_result.first;
     if (insert_result.second) {
         alloc_site->next = cpu_mem.alloc_site_list_head;
+        if (cpu_mem.alloc_site_list_head)
+        {
+            cpu_mem.alloc_site_list_head->prev = alloc_site;
+        }
         cpu_mem.alloc_site_list_head = alloc_site;
     }
     return alloc_site;
@@ -856,27 +877,11 @@ small_pool::alloc_site_holder(void* ptr) {
 
 #endif
 
-void*
-cpu_pages::allocate_small(unsigned size) {
-    auto idx = small_pool::size_to_idx(size);
-    auto& pool = small_pools[idx];
-    assert(size <= pool.object_size());
-    auto ptr = pool.allocate();
-#ifdef SEASTAR_HEAPPROF
-    if (get_heap_profiling_enabled() && ptr)
-    {
-        auto alloc_site = add_alloc_site(pool.object_size());
-        new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
-    }
-#endif
-    return ptr;
-}
-
 void cpu_pages::free_large(void* ptr) {
     pageidx idx = (reinterpret_cast<char*>(ptr) - mem()) / page_size;
     page* span = &pages[idx];
 #ifdef SEASTAR_HEAPPROF
-    if (get_heap_profiling_enabled())
+    if (span->alloc_site)
     {
         auto alloc_site = span->alloc_site;
         remove_alloc_site(alloc_site, span->span_size * page_size);
@@ -890,7 +895,7 @@ size_t cpu_pages::object_size(void* ptr) {
     if (span->pool) {
         auto s = span->pool->object_size();
 #ifdef SEASTAR_HEAPPROF
-        if (get_heap_profiling_enabled())
+        if (span->pool->is_sampled_pool())
         {
             // We must not allow the object to be extended onto the allocation_site_ptr field.
             if (!span->pool->objects_page_aligned()) {
@@ -938,7 +943,7 @@ void cpu_pages::free(void* ptr) {
     if (span->pool) {
         small_pool& pool = *span->pool;
 #ifdef SEASTAR_HEAPPROF
-        if (get_heap_profiling_enabled())
+        if (pool.is_sampled_pool())
         {
             allocation_site_ptr alloc_site = pool.alloc_site_holder(ptr);
             remove_alloc_site(alloc_site, pool.object_size());
@@ -951,27 +956,25 @@ void cpu_pages::free(void* ptr) {
 }
 
 void cpu_pages::free(void* ptr, size_t size) {
+#ifdef SEASTAR_HEAPPROF
+    // sized free can avoid accessing the `page` structure as an optimization.
+    // With memory sampling we always need to check the pool though to see
+    // whether this allocation was sampled. Hence, just defer to the non-sized
+    // implementation
+    (void) size;
+    free(ptr);
+#else
     // match action on allocate() so hit the right pool
     if (size <= sizeof(free_object)) {
         size = sizeof(free_object);
     }
     if (size <= max_small_allocation) {
-        size = object_size_with_alloc_site(size, get_heap_profiling_enabled());
         auto pool = &small_pools[small_pool::size_to_idx(size)];
-#ifdef SEASTAR_HEAPPROF
-        if (get_heap_profiling_enabled())
-        {
-            allocation_site_ptr alloc_site = pool->alloc_site_holder(ptr);
-            if (alloc_site) {
-                --alloc_site->count;
-                alloc_site->size -= pool->object_size();
-            }
-        }
-#endif
         pool->deallocate(ptr);
     } else {
         free_large(ptr);
     }
+#endif
 }
 
 bool
@@ -1008,13 +1011,10 @@ void cpu_pages::shrink(void* ptr, size_t new_size) {
         return;
     }
 #ifdef SEASTAR_HEAPPROF
-    if (get_heap_profiling_enabled())
-    {
-        auto alloc_site = span->alloc_site;
-        if (alloc_site) {
-            alloc_site->size -= span->span_size * page_size;
-            alloc_site->size += new_size_pages * page_size;
-        }
+    auto alloc_site = span->alloc_site;
+    if (alloc_site) {
+        alloc_site->size -= span->span_size * page_size;
+        alloc_site->size += new_size_pages * page_size;
     }
 #endif
     span->span_size = new_size_pages;
@@ -1208,8 +1208,8 @@ void cpu_pages::set_min_free_pages(size_t pages) {
     maybe_reclaim();
 }
 
-small_pool::small_pool(unsigned object_size) noexcept
-    : _object_size(object_size) {
+small_pool::small_pool(unsigned object_size, bool is_sampled) noexcept
+    : _object_size(object_size), _sampled_pool(is_sampled) {
     unsigned span_size = 1;
     auto span_bytes = [&] { return span_size * page_size; };
     auto waste = [&] { return (span_bytes() % _object_size) / (1.0 * span_bytes()); };
@@ -1239,6 +1239,7 @@ small_pool::small_pool(unsigned object_size) noexcept
 
     _max_free = std::max<unsigned>(100, span_bytes() * 2 / _object_size);
     _min_free = _max_free / 2;
+    _free = nullptr;
 }
 
 small_pool::~small_pool() {
@@ -1290,7 +1291,6 @@ small_pool::add_more_objects() {
         }
     }
     while (_free_count < goal) {
-        disable_backtrace_temporarily dbt;
         auto span_size = _span_sizes.preferred;
         auto data = reinterpret_cast<char*>(get_cpu_mem().allocate_large(span_size));
         if (!data) {
@@ -1399,6 +1399,40 @@ static inline cpu_pages& get_cpu_mem()
 static constexpr int debug_allocation_pattern = 0xab;
 #endif
 
+enum class alignment_t { aligned, unaligned };
+
+#ifdef SEASTAR_HEAPPROF
+template<alignment_t alignment>
+void* allocate_from_sampled_small_pool(size_t size) {
+    size = object_size_with_alloc_site(size);
+    if constexpr (alignment == alignment_t::aligned)
+    {
+        size = 1 << log2ceil(size);
+    }
+    auto idx = small_pool::size_to_idx(size);
+    auto& pool = get_cpu_mem().sampled_small_pools[idx];
+    assert(size <= pool.object_size());
+    void* ptr = pool.allocate();
+    auto alloc_site = get_cpu_mem().add_alloc_site(pool.object_size());
+    new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
+    return ptr;
+}
+
+#endif
+
+template<alignment_t alignment>
+void* allocate_from_small_pool(size_t size)
+{
+    if constexpr (alignment == alignment_t::aligned)
+    {
+        size = 1 << log2ceil(size);
+    }
+    auto idx = small_pool::size_to_idx(size);
+    auto& pool = get_cpu_mem().small_pools[idx];
+    assert(size <= pool.object_size());
+    return pool.allocate();
+}
+
 void* allocate(size_t size) {
     if (!is_reactor_thread) {
         if (original_malloc_func) {
@@ -1414,8 +1448,14 @@ void* allocate(size_t size) {
     }
     void* ptr;
     if (size <= max_small_allocation) {
-        size = object_size_with_alloc_site(size, get_heap_profiling_enabled());
-        ptr = get_cpu_mem().allocate_small(size);
+#ifdef SEASTAR_HEAPPROF
+        if (get_heap_profiling_enabled()) {
+            ptr = allocate_from_sampled_small_pool<alignment_t::unaligned>(size);
+        } else
+#endif
+        {
+            ptr = allocate_from_small_pool<alignment_t::unaligned>(size);
+        }
     } else {
         ptr = allocate_large(size);
     }
@@ -1447,8 +1487,14 @@ void* allocate_aligned(size_t align, size_t size) {
     if (size <= max_small_allocation && align <= page_size) {
         // Our small allocator only guarantees alignment for power-of-two
         // allocations which are not larger than a page.
-        size = 1 << log2ceil(object_size_with_alloc_site(size, get_heap_profiling_enabled()));
-        ptr = get_cpu_mem().allocate_small(size);
+#ifdef SEASTAR_HEAPPROF
+        if (get_heap_profiling_enabled()) {
+            ptr = allocate_from_sampled_small_pool<alignment_t::aligned>(size);
+        } else
+#endif
+        {
+            ptr = allocate_from_small_pool<alignment_t::aligned>(size);
+        }
     } else {
         ptr = allocate_large_aligned(align, size);
     }
@@ -1483,10 +1529,14 @@ void free_aligned(void* obj, size_t align, size_t size) {
     if (size <= sizeof(free_object)) {
         size = sizeof(free_object);
     }
+#ifndef SEASTAR_HEAPPROF
+    // See comment in the sized-free implementation below. With heap profiling we
+    // can skip this as sized-free defers to non-sized-free
     if (size <= max_small_allocation && align <= page_size) {
         // Same adjustment as allocate_aligned()
-        size = 1 << log2ceil(object_size_with_alloc_site(size, get_heap_profiling_enabled()));
+        size = 1 << log2ceil(size);
     }
+#endif
     free(obj, size);
 }
 

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -58,6 +58,7 @@
 #include <seastar/util/alloc_failure_injector.hh>
 #include <seastar/util/memory_diagnostics.hh>
 #include <seastar/util/std-compat.hh>
+#include <seastar/util/sampler.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/aligned_buffer.hh>
 #include <unordered_set>
@@ -138,6 +139,7 @@ __thread volatile int critical_alloc_section = 0;
 #include <seastar/core/posix.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <new>
+#include <random>
 #include <cstdint>
 #include <algorithm>
 #include <limits>
@@ -504,7 +506,8 @@ struct cpu_pages {
         alloc_sites_type alloc_sites;
     } asu;
     allocation_site_ptr alloc_site_list_head = nullptr; // For easy traversal of asu.alloc_sites from scylla-gdb.py
-    bool collect_backtrace = false;
+    sampler heap_prof_sampler;
+
     char* mem() { return memory; }
 
     void link(page_list& list, page* span);
@@ -514,9 +517,9 @@ struct cpu_pages {
         unsigned nr_pages;
     };
     void maybe_reclaim();
-    void* allocate_large_and_trim(unsigned nr_pages);
-    void* allocate_large(unsigned nr_pages);
-    void* allocate_large_aligned(unsigned align_pages, unsigned nr_pages);
+    void* allocate_large_and_trim(unsigned nr_pages, bool should_sample);
+    void* allocate_large(unsigned nr_pages, bool should_sample);
+    void* allocate_large_aligned(unsigned align_pages, unsigned nr_pages, bool should_sample);
     page* find_and_unlink_span(unsigned nr_pages);
     page* find_and_unlink_span_reclaiming(unsigned n_pages);
     void free_large(void* ptr);
@@ -548,6 +551,7 @@ struct cpu_pages {
     void warn_large_allocation(size_t size);
     allocation_site_ptr add_alloc_site(size_t allocated_size);
     void remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_size);
+    bool should_sample(size_t size);
     memory::memory_layout memory_layout();
     ~cpu_pages();
 };
@@ -560,51 +564,54 @@ static cpu_pages& get_cpu_mem();
 
 #ifdef SEASTAR_HEAPPROF
 
-void set_heap_profiling_enabled(bool enable) {
-    bool is_enabled = get_cpu_mem().collect_backtrace;
-    if (enable) {
-        if (!is_enabled) {
-            seastar_logger.info("Enabling heap profiler");
+void set_heap_profiling_sampling_rate(size_t sample_rate) {
+    bool current_sample_rate = get_cpu_mem().heap_prof_sampler.sampling_interval();
+    if (sample_rate) {
+        if (!current_sample_rate) {
+            seastar_logger.info("Enabling heap profiler - using {} bytes sampling rate", sample_rate);
+        } else {
+            seastar_logger.warn("Ignoring change to heap profiler sample rate as heap profiling is already turned on");
+            return;
         }
     } else {
-        if (is_enabled) {
+        if (current_sample_rate) {
             seastar_logger.info("Disabling heap profiler");
         }
     }
-    get_cpu_mem().collect_backtrace = enable;
+    get_cpu_mem().heap_prof_sampler.set_sampling_interval(sample_rate);
 }
 
-bool get_heap_profiling_enabled() {
-    return get_cpu_mem().collect_backtrace;
+size_t get_heap_profiling_sample_rate() {
+    return get_cpu_mem().heap_prof_sampler.sampling_interval();
 }
 
 static thread_local int64_t scoped_heap_profiling_embed_count = 0;
 
-scoped_heap_profiling::scoped_heap_profiling() noexcept {
+scoped_heap_profiling::scoped_heap_profiling(size_t sample_rate) noexcept {
     ++scoped_heap_profiling_embed_count;
-    set_heap_profiling_enabled(true);
+    set_heap_profiling_sampling_rate(sample_rate);
 }
 
 scoped_heap_profiling::~scoped_heap_profiling() {
     if (!--scoped_heap_profiling_embed_count) {
-        set_heap_profiling_enabled(false);
+        set_heap_profiling_sampling_rate(0);
     }
 }
 
 #else
 
-void set_heap_profiling_enabled(bool enable) {
+void set_heap_profiling_sampling_rate(size_t enable) {
     seastar_logger.warn("Seastar compiled without heap profiling support, heap profiler not supported;"
             " compile with the Seastar_HEAP_PROFILING=ON CMake option to add heap profiling support");
 }
 
-bool get_heap_profiling_enabled() {
+size_t get_heap_profiling_sample_rate() {
     // don't log here, called on all paths
-    return false;
+    return 0;
 }
 
-scoped_heap_profiling::scoped_heap_profiling() noexcept {
-    set_heap_profiling_enabled(true); // let it print the warning
+scoped_heap_profiling::scoped_heap_profiling(size_t sample_rate) noexcept {
+    set_heap_profiling_sampling_rate(sample_rate); // let it print the warning
 }
 
 scoped_heap_profiling::~scoped_heap_profiling() {
@@ -727,7 +734,7 @@ void cpu_pages::maybe_reclaim() {
 }
 
 void*
-cpu_pages::allocate_large_and_trim(unsigned n_pages) {
+cpu_pages::allocate_large_and_trim(unsigned n_pages, bool should_sample) {
     // Avoid exercising the reclaimers for requests we'll not be able to satisfy
     // nr_pages might be zero during startup, so check for that too
     if (nr_pages && n_pages >= nr_pages) {
@@ -750,7 +757,7 @@ cpu_pages::allocate_large_and_trim(unsigned n_pages) {
     span->span_size = span_end->span_size = span_size;
     span->pool = nullptr;
 #ifdef SEASTAR_HEAPPROF
-    if (get_heap_profiling_enabled())
+    if (should_sample)
     {
         auto alloc_site = add_alloc_site(span->span_size * page_size);
         span->alloc_site = alloc_site;
@@ -775,7 +782,7 @@ cpu_pages::add_alloc_site(size_t allocated_size) {
     allocation_site_ptr alloc_site = get_allocation_site();
     if (alloc_site) {
         ++alloc_site->count;
-        alloc_site->size += std::max(sampler.sampling_interval(), allocated_size);
+        alloc_site->size += heap_prof_sampler.sample_size(allocated_size);
     }
 
     return alloc_site;
@@ -785,7 +792,7 @@ void
 cpu_pages::remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_size) {
     if (alloc_site) {
         --alloc_site->count;
-        alloc_site->size -= std::max(sampler.sampling_interval(), deallocated_size);
+        alloc_site->size -= heap_prof_sampler.sample_size(deallocated_size);
         if (alloc_site->count == 0)
         {
             if (alloc_site->prev)
@@ -806,6 +813,11 @@ cpu_pages::remove_alloc_site(allocation_site_ptr alloc_site, size_t deallocated_
     }
 }
 
+bool
+cpu_pages::should_sample(size_t size) {
+    return heap_prof_sampler.should_sample(size);
+}
+
 void
 inline
 cpu_pages::check_large_allocation(size_t size) {
@@ -815,25 +827,20 @@ cpu_pages::check_large_allocation(size_t size) {
 }
 
 void*
-cpu_pages::allocate_large(unsigned n_pages) {
+cpu_pages::allocate_large(unsigned n_pages, bool should_sample) {
     check_large_allocation(n_pages * page_size);
-    return allocate_large_and_trim(n_pages);
+    return allocate_large_and_trim(n_pages, should_sample);
 }
 
 void*
-cpu_pages::allocate_large_aligned(unsigned align_pages, unsigned n_pages) {
+cpu_pages::allocate_large_aligned(unsigned align_pages, unsigned n_pages, bool should_sample) {
     check_large_allocation(n_pages * page_size);
     // buddy allocation is always aligned
-    return allocate_large_and_trim(n_pages);
+    return allocate_large_and_trim(n_pages, should_sample);
 }
 
-disable_backtrace_temporarily::disable_backtrace_temporarily() {
-    _old = get_cpu_mem().collect_backtrace;
-    get_cpu_mem().collect_backtrace = false;
-}
-
-disable_backtrace_temporarily::~disable_backtrace_temporarily() {
-    get_cpu_mem().collect_backtrace = _old;
+disable_backtrace_temporarily::disable_backtrace_temporarily()
+    : _disable_sampling(cpu_mem.heap_prof_sampler.pause_sampling()) {
 }
 
 static
@@ -844,7 +851,7 @@ simple_backtrace get_backtrace() noexcept {
 
 static
 allocation_site_ptr get_allocation_site() {
-    if (!cpu_mem.is_initialized() || !cpu_mem.collect_backtrace) {
+    if (!cpu_mem.is_initialized() || !cpu_mem.heap_prof_sampler.sampling_interval()) {
         return nullptr;
     }
     // TODO: limit size of alloc_sites
@@ -1118,7 +1125,7 @@ void cpu_pages::do_resize(size_t new_size, allocate_system_memory_fn alloc_sys_m
     // one past last page structure is a sentinel
     auto new_page_array_pages = align_up(sizeof(page[new_pages + 1]), page_size) / page_size;
     auto new_page_array
-        = reinterpret_cast<page*>(allocate_large(new_page_array_pages));
+        = reinterpret_cast<page*>(allocate_large(new_page_array_pages, false));
     if (!new_page_array) {
         throw std::bad_alloc();
     }
@@ -1292,10 +1299,10 @@ small_pool::add_more_objects() {
     }
     while (_free_count < goal) {
         auto span_size = _span_sizes.preferred;
-        auto data = reinterpret_cast<char*>(get_cpu_mem().allocate_large(span_size));
+        auto data = reinterpret_cast<char*>(get_cpu_mem().allocate_large(span_size, false));
         if (!data) {
             span_size = _span_sizes.fallback;
-            data = reinterpret_cast<char*>(get_cpu_mem().allocate_large(span_size));
+            data = reinterpret_cast<char*>(get_cpu_mem().allocate_large(span_size, false));
             if (!data) {
                 return;
             }
@@ -1350,21 +1357,21 @@ abort_on_underflow(size_t size) {
     }
 }
 
-void* allocate_large(size_t size) {
+void* allocate_large(size_t size, bool should_sample) {
     abort_on_underflow(size);
     unsigned size_in_pages = (size + page_size - 1) >> page_bits;
     if ((size_t(size_in_pages) << page_bits) < size) {
         return nullptr; // (size + page_size - 1) caused an overflow
     }
-    return get_cpu_mem().allocate_large(size_in_pages);
+    return get_cpu_mem().allocate_large(size_in_pages, should_sample);
 
 }
 
-void* allocate_large_aligned(size_t align, size_t size) {
+void* allocate_large_aligned(size_t align, size_t size, bool should_sample) {
     abort_on_underflow(size);
     unsigned size_in_pages = (size + page_size - 1) >> page_bits;
     unsigned align_in_pages = std::max(align, page_size) >> page_bits;
-    return get_cpu_mem().allocate_large_aligned(align_in_pages, size_in_pages);
+    return get_cpu_mem().allocate_large_aligned(align_in_pages, size_in_pages, should_sample);
 }
 
 void free_large(void* ptr) {
@@ -1446,10 +1453,16 @@ void* allocate(size_t size) {
     if (size <= sizeof(free_object)) {
         size = sizeof(free_object);
     }
+
+#ifdef SEASTAR_HEAPPROF
+    bool should_sample = get_cpu_mem().should_sample(size);
+#else
+    bool should_sample = get_cpu_mem().should_sample(size);
+#endif
     void* ptr;
     if (size <= max_small_allocation) {
 #ifdef SEASTAR_HEAPPROF
-        if (get_heap_profiling_enabled()) {
+        if (should_sample) {
             ptr = allocate_from_sampled_small_pool<alignment_t::unaligned>(size);
         } else
 #endif
@@ -1457,7 +1470,7 @@ void* allocate(size_t size) {
             ptr = allocate_from_small_pool<alignment_t::unaligned>(size);
         }
     } else {
-        ptr = allocate_large(size);
+        ptr = allocate_large(size, should_sample);
     }
     if (!ptr) {
         on_allocation_failure(size);
@@ -1483,12 +1496,17 @@ void* allocate_aligned(size_t align, size_t size) {
     if (size <= sizeof(free_object)) {
         size = std::max(sizeof(free_object), align);
     }
+#ifdef SEASTAR_HEAPPROF
+    bool should_sample = get_cpu_mem().should_sample(size);
+#else
+    bool should_sample = false;
+#endif
     void* ptr;
     if (size <= max_small_allocation && align <= page_size) {
         // Our small allocator only guarantees alignment for power-of-two
         // allocations which are not larger than a page.
 #ifdef SEASTAR_HEAPPROF
-        if (get_heap_profiling_enabled()) {
+        if (should_sample) {
             ptr = allocate_from_sampled_small_pool<alignment_t::aligned>(size);
         } else
 #endif
@@ -1496,7 +1514,7 @@ void* allocate_aligned(size_t align, size_t size) {
             ptr = allocate_from_small_pool<alignment_t::aligned>(size);
         }
     } else {
-        ptr = allocate_large_aligned(align, size);
+        ptr = allocate_large_aligned(align, size, should_sample);
     }
     if (!ptr) {
         on_allocation_failure(size);
@@ -1918,13 +1936,13 @@ static bool try_trigger_error_injector() {
     }
 }
 
-std::vector<allocation_site> memory_profile() {
+std::vector<allocation_site> sampled_memory_profile() {
     disable_backtrace_temporarily dbt;
     std::vector<allocation_site> ret(get_cpu_mem().asu.alloc_sites.begin(), get_cpu_mem().asu.alloc_sites.end());
     return ret;
 }
 
-size_t memory_profile(std::vector<allocation_site>& output) {
+size_t sampled_memory_profile(std::vector<allocation_site>& output) {
     auto to_copy = std::min(output.size(), get_cpu_mem().asu.alloc_sites.size());
     std::copy_n(get_cpu_mem().asu.alloc_sites.begin(), to_copy, output.begin());
     return to_copy;
@@ -2333,30 +2351,27 @@ namespace seastar {
 namespace memory {
 
 disable_backtrace_temporarily::disable_backtrace_temporarily() {
-    (void)_old;
+    (void)_disable_sampling;
 }
 
-disable_backtrace_temporarily::~disable_backtrace_temporarily() {
-}
-
-void set_heap_profiling_enabled(bool enabled) {
+void set_heap_profiling_sampling_rate(size_t) {
     seastar_logger.warn("Seastar compiled with default allocator, heap profiler not supported");
 }
 
-bool get_heap_profiling_enabled() {
-    return false;
+size_t get_heap_profiling_sample_rate() {
+    return 0;
 }
 
-std::vector<allocation_site> memory_profile() {
+std::vector<allocation_site> sampled_memory_profile() {
     return {};
 }
 
-size_t memory_profile(std::vector<allocation_site>&) { 
-    return 0; 
+size_t sampled_memory_profile(std::vector<allocation_site>&) {
+    return 0;
 }
 
-scoped_heap_profiling::scoped_heap_profiling() noexcept {
-    set_heap_profiling_enabled(true); // let it print the warning
+scoped_heap_profiling::scoped_heap_profiling(size_t sample_rate) noexcept {
+    set_heap_profiling_sampling_rate(sample_rate); // let it print the warning
 }
 
 scoped_heap_profiling::~scoped_heap_profiling() {

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -51,6 +51,23 @@
 // by size.  When spans are broken up or coalesced, they may move into new lists.
 // Spans have a size that is a power-of-two and are naturally aligned (aka buddy
 // allocator)
+//
+// If compiled with SEASTAR_HEAPPROF seastar features a sampling memory
+// profiler. Allocations are sampled at random (see `sampler` for the sampling
+// logic) and tracked. The sampled live set can be retrieved with
+// `sampled_memory_profile()`. Sampled allocations carry an extra
+// allocation_site pointer with them which is used on free to remove them from
+// the sampled live set.
+//
+// Large allocations are tracked via a pointer to the allocation_site which is
+// stored on the page structure. To check whether an allocation was sampled or
+// not this pointer is being looked at on free.
+//
+// Small allocations store an extra 8 bytes at the end of their allocation.
+// Sampled allocations are allocated in a separate set of small pools. Hence, to
+// check whether an allocation was sampled or not one only has to look at the
+// tag in pool.
+//
 
 #include <seastar/core/cacheline.hh>
 #include <seastar/core/memory.hh>

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3753,7 +3753,7 @@ reactor_options::reactor_options(program_options::option_group* parent_group)
                 "Maximum number of I/O control blocks (IOCBs) to allocate per shard. This translates to the number of sockets supported per shard."
                 " Requires tuning /proc/sys/fs/aio-max-nr. Only valid for the linux-aio reactor backend (see --reactor-backend).")
 #ifdef SEASTAR_HEAPPROF
-    , heapprof(*this, "heapprof", "enable seastar heap profiling")
+    , heapprof(*this, "heapprof", 0, "Enable seastar heap profiling. Sample every ARG bytes. 0 means off")
 #else
     , heapprof(*this, "heapprof", program_options::unused{})
 #endif
@@ -4277,12 +4277,12 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     reactor_cfg.max_networking_aio_io_control_blocks = adjust_max_networking_aio_io_control_blocks(reactor_opts.max_networking_io_control_blocks.get_value());
 
 #ifdef SEASTAR_HEAPPROF
-    bool heapprof_enabled = reactor_opts.heapprof;
-    if (heapprof_enabled) {
-        memory::set_heap_profiling_enabled(heapprof_enabled);
+    size_t heapprof_sampling_rate = reactor_opts.heapprof.get_value();
+    if (heapprof_sampling_rate) {
+        memory::set_heap_profiling_sampling_rate(heapprof_sampling_rate);
     }
 #else
-    bool heapprof_enabled = false;
+    size_t heapprof_sampling_rate = 0;
 #endif
 
 #ifdef SEASTAR_HAVE_DPDK
@@ -4361,7 +4361,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     auto smp_tmain = smp::_tmain;
     for (i = 1; i < smp::count; i++) {
         auto allocation = allocations[i];
-        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_enabled, mbind, backend_selector, reactor_cfg] {
+        create_thread([this, smp_tmain, inited, &reactors_registered, &smp_queues_constructed, &smp_opts, &reactor_opts, &reactors, hugepages_path, i, allocation, assign_io_queues, alloc_io_queues, thread_affinity, heapprof_sampling_rate, mbind, backend_selector, reactor_cfg] {
           try {
             // initialize thread_locals that are equal across all reacto threads of this smp instance
             smp::_tmain = smp_tmain;
@@ -4373,8 +4373,8 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
             if (smp_opts.memory_allocator == memory_allocator::seastar) {
                 memory::configure(allocation.mem, mbind, hugepages_path);
             }
-            if (heapprof_enabled) {
-                memory::set_heap_profiling_enabled(heapprof_enabled);
+            if (heapprof_sampling_rate) {
+                memory::set_heap_profiling_sampling_rate(heapprof_sampling_rate);
             }
             sigset_t mask;
             sigfillset(&mask);

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -79,3 +79,6 @@ seastar_add_test (smp_submit_to
 
 seastar_add_test (coroutine
   SOURCES coroutine_perf.cc)
+
+seastar_add_test (allocator
+  SOURCES allocator_perf.cc)

--- a/tests/perf/allocator_perf.cc
+++ b/tests/perf/allocator_perf.cc
@@ -1,0 +1,139 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2023 ScyllaDB
+ */
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <seastar/core/memory.hh>
+#include <sys/mman.h>
+
+struct allocator_test {
+    static constexpr size_t COUNT = 1000;
+    std::array<void *, COUNT> _pointers{};
+};
+
+struct allocator_test_split : public allocator_test {
+    enum alloc_test_flags {
+      MEASURE_ALLOC = 1 << 0,
+      MEASURE_FREE = 2 << 0,
+    };
+
+    template <int M> struct maybe_measure {
+        maybe_measure() {
+          if constexpr (M)
+            perf_tests::start_measuring_time();
+        }
+        ~maybe_measure() {
+          if constexpr (M)
+            perf_tests::stop_measuring_time();
+        }
+    };
+
+    template <size_t alloc_size, alloc_test_flags F = alloc_test_flags(MEASURE_ALLOC |
+                                                    MEASURE_FREE)>
+    size_t alloc_test() {
+        {
+          maybe_measure<F & MEASURE_ALLOC> m;
+          for (auto &p : _pointers) {
+            p = std::malloc(alloc_size);
+          }
+        }
+
+        {
+          maybe_measure<F & MEASURE_FREE> m;
+          for (auto &p : _pointers) {
+            std::free(p);
+          }
+        }
+
+        return _pointers.size();
+    }
+};
+
+PERF_TEST_F(allocator_test_split, alloc_only) { return alloc_test<8, MEASURE_ALLOC>(); }
+
+PERF_TEST_F(allocator_test_split, free_only) { return alloc_test<8, MEASURE_FREE>(); }
+
+PERF_TEST_F(allocator_test_split, alloc_free) { return alloc_test<8>(); }
+
+// this test doesn't serve much value. It should take about 10 times as the
+// single alloc test above. If not, something is wrong.
+PERF_TEST_F(allocator_test, single_alloc_and_free_small_many)
+{
+    const std::size_t allocs = 10;
+
+    for (std::size_t i = 0; i < allocs; ++i)
+    {
+        auto ptr = malloc(10);
+        perf_tests::do_not_optimize(ptr);
+        _pointers[i] = ptr;
+    }
+
+    for (std::size_t i = 0; i < allocs; ++i)
+    {
+        free(_pointers[i]);
+    }
+}
+
+// Allocate from more than one page. Should also not suffer a perf penalty 
+// As we should have at least min free of 50 objects (hard coded internally)
+PERF_TEST_F(allocator_test, single_alloc_and_free_small_many_cross_page)
+{
+    const std::size_t alloc_size = 1024;
+    const std::size_t allocs = (seastar::memory::page_size / alloc_size) + 1;
+
+    for (std::size_t i = 0; i < allocs; ++i)
+    {
+        auto ptr = malloc(alloc_size);
+        perf_tests::do_not_optimize(ptr);
+        _pointers[i] = ptr;
+    }
+
+    for (std::size_t i = 0; i < allocs; ++i)
+    {
+        free(_pointers[i]);
+    }
+}
+
+// Include an allocation in the benchmark that will require going to the large pool
+// for more data for the small pool
+PERF_TEST_F(allocator_test, single_alloc_and_free_small_many_cross_page_alloc_more)
+{
+    const std::size_t alloc_size = 1024;
+    const std::size_t allocs = 101; // at 1024 alloc size we will have a _max_free of 100 objects
+
+    for (std::size_t i = 0; i < allocs; ++i)
+    {
+        auto ptr = malloc(alloc_size);
+        perf_tests::do_not_optimize(ptr);
+        _pointers[i] = ptr;
+    }
+
+    for (std::size_t i = 0; i < allocs; ++i)
+    {
+        free(_pointers[i]);
+    }
+}
+
+PERF_TEST_F(allocator_test_split, alloc_only_large) { return alloc_test<32000, MEASURE_ALLOC>(); }
+
+PERF_TEST_F(allocator_test_split, free_only_large) { return alloc_test<32000, MEASURE_FREE>(); }
+
+PERF_TEST_F(allocator_test_split, alloc_free_large) { return alloc_test<32000>(); }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -132,6 +132,12 @@ function (seastar_add_test name)
           SEASTAR_THREAD_STACK_GUARDS)
     endif ()
 
+    if (Seastar_HEAP_PROFILING)
+      target_compile_definitions (${executable_target}
+        PRIVATE
+          SEASTAR_HEAPPROF)
+    endif ()
+
     target_include_directories (${executable_target}
       PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -316,14 +316,14 @@ SEASTAR_TEST_CASE(test_diagnostics_allocation) {
 SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
 {
     {
-        auto stats = seastar::memory::memory_profile();
+        auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     std::size_t count = 100;
     std::vector<volatile char*> ptrs(count);
 
-    seastar::memory::set_heap_profiling_enabled(true);
+    seastar::memory::set_heap_profiling_sampling_rate(100);
 
     #pragma nounroll
     for (std::size_t i = 0; i < count / 2; ++i)
@@ -342,31 +342,25 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
     }
 
     // NB: the test framework allocates
-    seastar::memory::set_heap_profiling_enabled(0);
+    seastar::memory::set_heap_profiling_sampling_rate(0);
 
     {
-        auto stats = seastar::memory::memory_profile();
-
-        for (const auto& stat : stats)
-        {
-            std::cout << stat.backtrace << std::endl;
-        }
-
+        auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 2);
         BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 100);
     }
 
-    seastar::memory::set_heap_profiling_enabled(false);
+    seastar::memory::set_heap_profiling_sampling_rate(100);
 
     for (auto ptr : ptrs)
     {
         free((void*)ptr);
     }
 
-    seastar::memory::set_heap_profiling_enabled(0);
+    seastar::memory::set_heap_profiling_sampling_rate(0);
 
     {
-        auto stats = seastar::memory::memory_profile();
+        auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
@@ -376,14 +370,14 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
 SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
 {
     {
-        auto stats = seastar::memory::memory_profile();
+        auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
     std::size_t count = 100;
     std::vector<volatile char*> ptrs(count);
 
-    seastar::memory::set_heap_profiling_enabled(1000000);
+    seastar::memory::set_heap_profiling_sampling_rate(1000000);
 
     #pragma nounroll
     for (std::size_t i = 0; i < count / 2; ++i)
@@ -402,25 +396,25 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     }
 
     // NB: the test framework allocate
-    seastar::memory::set_heap_profiling_enabled(0);
+    seastar::memory::set_heap_profiling_sampling_rate(0);
 
     {
-        auto stats = seastar::memory::memory_profile();
+        auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 2);
         BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 1000000);
     }
 
-    seastar::memory::set_heap_profiling_enabled(1000000);
+    seastar::memory::set_heap_profiling_sampling_rate(1000000);
 
     for (auto ptr : ptrs)
     {
         free((void*)ptr);
     }
 
-    seastar::memory::set_heap_profiling_enabled(0);
+    seastar::memory::set_heap_profiling_sampling_rate(0);
 
     {
-        auto stats = seastar::memory::memory_profile();
+        auto stats = seastar::memory::sampled_memory_profile();
         // NOTE this is because right now the tracking structure doesn't delete call sites ever
         BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -422,6 +422,32 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     return seastar::make_ready_future();
 }
 
+SEASTAR_TEST_CASE(test_sampled_profile_collection_max_sites)
+{
+    std::size_t count = 1010;
+    std::vector<volatile char*> ptrs(count);
+
+    seastar::memory::set_heap_profiling_sampling_rate(100);
+
+    #pragma unroll 1010
+    for (std::size_t i = 0; i < count; ++i)
+    {
+        volatile char* ptr = static_cast<char*>(malloc(1000));
+        *ptr = 'c'; // to prevent compiler from considering this a dead allocation and optimizing it out
+        ptrs[i] = ptr;
+    }
+
+    seastar::memory::set_heap_profiling_sampling_rate(0);
+
+    {
+        auto stats = seastar::memory::sampled_memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 1000);
+    }
+
+    return seastar::make_ready_future();
+}
+
+
 #endif // SEASTAR_HEAPPROF
 
 #endif // #ifndef SEASTAR_DEFAULT_ALLOCATOR

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -311,6 +311,42 @@ SEASTAR_TEST_CASE(test_diagnostics_allocation) {
     return seastar::make_ready_future();
 }
 
+#ifdef SEASTAR_HEAPPROF
+
+SEASTAR_TEST_CASE(test_sampled_profile_collection)
+{
+    BOOST_REQUIRE(!seastar::memory::get_heap_profiling_enabled());
+    seastar::memory::set_heap_profiling_enabled(true);
+    BOOST_REQUIRE(seastar::memory::get_heap_profiling_enabled());
+
+    {
+        auto stats = seastar::memory::memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+    }
+
+    volatile char* ptr = static_cast<char*>(malloc(10));
+    *ptr = 'c'; // to prevent compiler from considering this a dead allocation and optimizing it out
+
+    {
+        auto stats = seastar::memory::memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 1);
+        BOOST_REQUIRE_EQUAL(stats[0].size, 32); // 10 + 8 falls into 32 byte pool
+    }
+
+    free((void*)ptr);
+
+    {
+        auto stats = seastar::memory::memory_profile();
+        BOOST_REQUIRE_EQUAL(stats.size(), 0);
+    }
+
+    // Needed for now because we can't differentiate between sampled allocations and non-sampled ones
+    seastar::memory::set_heap_profiling_enabled(false);
+
+    return seastar::make_ready_future();
+}
+
+#endif // SEASTAR_HEAPPROF
 
 #endif // #ifndef SEASTAR_DEFAULT_ALLOCATOR
 


### PR DESCRIPTION
As discussed this is the current state:

Commits should stand on their own. The most interesting ones are probably "use sampler" and "use separate pool" which implement the meat. 

It's not optimized yet to the last instruction as that will require reshuffling a bit of code but I first want to confirm we are happy with the general approach for a v1.

I am using this with https://github.com/redpanda-data/redpanda/compare/dev...StephanDollberg:redpanda:support-mem-profiling?expand=1 (seastar change not committed there):



I am using OMB benchrunner using this config: https://gist.github.com/StephanDollberg/3d51e3ea029708f7aed49a277220cb26 I am happy to try other ones if you think they are more fitting.

These are the last lines of three different runs each:

current dev:

```
[client 0:0] 16:45:01.158 [main] INFO - E2E Latency (ms) avg: 3.828 - 50%: 3.731 - 99%: 7.073 - 99.9%: 11.093 - Max: 19.623
[client 0:0] 16:45:01.413 [main] INFO - ----- Aggregated Pub Latency (ms) avg: 2.689 - 50%: 2.253 - 95%: 3.460 - 99%: 6.235 - 99.9%: 115.282 - 99.99%: 297.557 - Max: 566.035 | Pub Delay (us)  avg: 169.938 - 50%: 24.000 - 95%: 64.000 - 99%: 77.000 - 99.9%: 57342.000 - 99.99%: 68196.000 - Max: 72037.000

[client 0:0] 16:40:11.059 [main] INFO - E2E Latency (ms) avg: 3.922 - 50%: 3.798 - 99%: 7.706 - 99.9%: 11.915 - Max: 23.610
[client 0:0] 16:40:11.302 [main] INFO - ----- Aggregated Pub Latency (ms) avg: 2.711 - 50%: 2.288 - 95%: 3.703 - 99%: 6.601 - 99.9%: 101.424 - 99.99%: 250.523 - Max: 468.353 | Pub Delay (us)  avg: 157.477 - 50%: 25.000 - 95%: 64.000 - 99%: 77.000 - 99.9%: 53500.000 - 99.99%: 67445.000 - Max: 74282.000

[client 0:0] 16:29:43.995 [main] INFO - E2E Latency (ms) avg: 4.033 - 50%: 3.884 - 99%: 7.773 - 99.9%: 11.462 - Max: 18.480
[client 0:0] 16:29:44.260 [main] INFO - ----- Aggregated Pub Latency (ms) avg: 3.001 - 50%: 2.337 - 95%: 3.967 - 99%: 7.399 - 99.9%: 170.877 - 99.99%: 398.539 - Max: 609.247 | Pub Delay (us)  avg: 219.166 - 50%: 24.000 - 95%: 64.000 - 99%: 77.000 - 99.9%: 79371.000 - 99.99%: 96960.000 - Max: 103688.000
```

1MB sampling:

```
[client 0:0] 17:04:58.938 [main] INFO - E2E Latency (ms) avg: 4.207 - 50%: 4.049 - 99%: 7.960 - 99.9%: 12.608 - Max: 26.739
[client 0:0] 17:04:59.205 [main] INFO - ----- Aggregated Pub Latency (ms) avg: 3.125 - 50%: 2.433 - 95%: 4.011 - 99%: 6.609 - 99.9%: 186.264 - 99.99%: 369.935 - Max: 591.547 | Pub Delay (us)  avg: 216.450 - 50%: 24.000 - 95%: 64.000 - 99%: 78.000 - 99.9%: 71178.000 - 99.99%: 97655.000 - Max: 99394.000

[client 0:0] 17:07:49.009 [main] INFO - E2E Latency (ms) avg: 4.190 - 50%: 4.027 - 99%: 8.137 - 99.9%: 12.315 - Max: 32.772
[client 0:0] 17:07:49.294 [main] INFO - ----- Aggregated Pub Latency (ms) avg: 3.164 - 50%: 2.464 - 95%: 4.232 - 99%: 7.424 - 99.9%: 173.275 - 99.99%: 417.215 - Max: 657.475 | Pub Delay (us)  avg: 312.114 - 50%: 24.000 - 95%: 64.000 - 99%: 80.000 - 99.9%: 99721.000 - 99.99%: 127613.000 - Max: 130623.000

[client 0:0] 17:12:33.201 [main] INFO - E2E Latency (ms) avg: 3.968 - 50%: 3.855 - 99%: 7.483 - 99.9%: 11.334 - Max: 18.778
[client 0:0] 17:12:33.452 [main] INFO - ----- Aggregated Pub Latency (ms) avg: 2.799 - 50%: 2.363 - 95%: 3.746 - 99%: 6.397 - 99.9%: 118.937 - 99.99%: 279.579 - Max: 449.807 | Pub Delay (us)  avg: 135.455 - 50%: 24.000 - 95%: 64.000 - 99%: 76.000 - 99.9%: 55372.000 - 99.99%: 79435.000 - Max: 85011.000
```

So it seems like it maybe has a ~2% perf impact but it certainly is in the noise. I am not sure whether we have nice ways of aggregating these or comparing them.

The following is a flamegraph generated during one such run (with the periodic logging printing the top-20 stacks):

![flamegraph](https://user-images.githubusercontent.com/2904723/234948764-db9b3e03-c5ba-4f9d-a934-8926d4932f4b.svg)

Note the output-to-flamegraph script currently doesn't strip return types from functions so it looks a bit meh.

I will work on exposing the fullset from the admin API next.




