### PR TITLE
file: wrap syncfs syscall

### DIFF
--- a/include/seastar/core/file.hh
+++ b/include/seastar/core/file.hh
@@ -135,6 +135,7 @@ public:
     }
 
     virtual future<> flush(void) = 0;
+    virtual future<> syncfs(void) = 0;
     virtual future<struct stat> stat(void) = 0;
     virtual future<> truncate(uint64_t length) = 0;
     virtual future<> discard(uint64_t offset, uint64_t length) = 0;
@@ -373,6 +374,10 @@ public:
     /// Prior to a flush, written data may or may not survive a power failure.  After
     /// a flush, data is guaranteed to be on disk.
     future<> flush() noexcept;
+
+    /// Causes any dirty data on any file on the same filesystem as this file to
+    /// be flushed to disk.
+    future<> syncfs() noexcept;
 
     /// Returns \c stat information about the file.
     future<struct stat> stat() noexcept;

--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -685,6 +685,7 @@ private:
 
     future<struct stat> fstat(int fd) noexcept;
     future<struct statfs> fstatfs(int fd) noexcept;
+    future<> syncfs(int fd) noexcept;
     friend future<shared_ptr<file_impl>> make_file_impl(int fd, file_open_options options, int flags) noexcept;
 public:
     future<> readable(pollable_fd_state& fd);

--- a/src/core/file-impl.hh
+++ b/src/core/file-impl.hh
@@ -90,6 +90,7 @@ protected:
 public:
     virtual ~posix_file_impl() override;
     future<> flush(void) noexcept override;
+    future<> syncfs(void) noexcept override;
     future<struct stat> stat(void) noexcept override;
     future<> truncate(uint64_t length) noexcept override;
     future<> discard(uint64_t offset, uint64_t length) noexcept override;

--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -185,6 +185,11 @@ posix_file_impl::flush(void) noexcept {
     return engine().fdatasync(_fd);
 }
 
+future<>
+posix_file_impl::syncfs(void) noexcept {
+    return engine().syncfs(_fd);
+}
+
 future<struct stat>
 posix_file_impl::stat() noexcept {
     return engine().fstat(_fd);
@@ -1215,6 +1220,14 @@ future<struct stat> file::stat() noexcept {
 future<> file::flush() noexcept {
   try {
     return _file_impl->flush();
+  } catch (...) {
+    return current_exception_as_future();
+  }
+}
+
+future<> file::syncfs() noexcept {
+  try {
+    return _file_impl->syncfs();
   } catch (...) {
     return current_exception_as_future();
   }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2225,6 +2225,16 @@ reactor::fstatfs(int fd) noexcept {
     });
 }
 
+future<>
+reactor::syncfs(int fd) noexcept {
+    return _thread_pool->submit<syscall_result<int>>([fd] {
+        auto ret = ::syncfs(fd);
+        return wrap_syscall(ret);
+    }).then([] (syscall_result<int> sr) {
+        sr.throw_if_error();
+    });
+}
+
 future<struct statvfs>
 reactor::statvfs(std::string_view pathname) noexcept {
     // Allocating memory for a sstring can throw, hence the futurize_invoke


### PR DESCRIPTION
It is prudent to syncfs on startup if relying
on all writes from previous instances of one's program to be persistent.