### PR TITLE
[v23.1.x] chunked_fifo: const_iterator: use the base class ctor

### DIFF
--- a/include/seastar/core/chunked_fifo.hh
+++ b/include/seastar/core/chunked_fifo.hh
@@ -161,7 +161,7 @@ public:
         iterator() noexcept = default;
     };
     class const_iterator : public basic_iterator<const T> {
-        using basic_iterator<T>::basic_iterator;
+        using basic_iterator<const T>::basic_iterator;
     public:
         const_iterator() noexcept = default;
         inline const_iterator(iterator o) noexcept;

--- a/tests/unit/chunked_fifo_test.cc
+++ b/tests/unit/chunked_fifo_test.cc
@@ -356,3 +356,23 @@ BOOST_AUTO_TEST_CASE(chunked_fifo_iterator) {
         BOOST_REQUIRE(std::equal(fifo.begin(), fifo.end(), reference.begin(), reference.end()));
     }
 }
+
+BOOST_AUTO_TEST_CASE(chunked_fifo_const_iterator) {
+    constexpr auto items_per_chunk = 8;
+    auto fifo = chunked_fifo<int, items_per_chunk>{};
+    auto reference = std::deque<int>{};
+
+    BOOST_REQUIRE(fifo.cbegin() == fifo.cend());
+
+    for (int i = 0; i < items_per_chunk * 4; ++i) {
+        fifo.push_back(i);
+        reference.push_back(i);
+        BOOST_REQUIRE(std::equal(fifo.cbegin(), fifo.cend(), reference.cbegin(), reference.cend()));
+    }
+
+    for (int i = 0; i < items_per_chunk * 2; ++i) {
+        fifo.pop_front();
+        reference.pop_front();
+        BOOST_REQUIRE(std::equal(fifo.cbegin(), fifo.cend(), reference.cbegin(), reference.cend()));
+    }
+}


### PR DESCRIPTION
Need to be using `basic_iterator<const T>`
rather than `basic_iterator<T>`

Otherwise, we get the following compilation error:
```
/home/bhalevy/dev/seastar/include/seastar/core/chunked_fifo.hh:164:15: error: using declaration refers into 'basic_iterator<int>::', which is not a base class of 'const_iterator'
        using basic_iterator<T>::basic_iterator;
              ^~~~~~~~~~~~~~~~~~~
```

Added a unit test that doesn't build without the fix.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>
(cherry picked from commit 6e48abed8e9b068270d90160cafd137d9c85af17)