### PR TITLE
Reactor main loop optimziaton 

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -62,6 +62,7 @@
 #include <seastar/core/scheduling_specific.hh>
 #include <seastar/core/smp_options.hh>
 #include <seastar/util/log.hh>
+#include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/read_first_line.hh>
 #include "core/reactor_backend.hh"
 #include "core/syscall_result.hh"
@@ -3298,7 +3299,7 @@ int reactor::do_run() {
     auto check_for_work = [this] () {
         return poll_once() || have_more_tasks();
     };
-    std::function<bool()> pure_check_for_work = [this] () {
+    const noncopyable_function<bool()> pure_check_for_work = [this] () {
         return pure_poll_once() || have_more_tasks();
     };
     _cpu_profiler->start();

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -3295,7 +3295,7 @@ int reactor::do_run() {
 
     bool idle = false;
 
-    std::function<bool()> check_for_work = [this] () {
+    auto check_for_work = [this] () {
         return poll_once() || have_more_tasks();
     };
     std::function<bool()> pure_check_for_work = [this] () {


### PR DESCRIPTION
Two minor opts in the reactor main loop:

 - Use lambda type not `std::function` for `check_work`
 - Use `ss::noncopyable_function` for `pure_check_work`
 
See commit messages for details on the individual changes.

It's hard to analyze exactly the effect of this change since speeding up the main reactor loop does not directly lead to a utilization drop: the main loop simply spins faster (things like reactor sleep are time based, not iteration based). However, for one test which involves a fair about of spinning this did seem to speed up the reactor loop by about 2%.