### PR TITLE
metrics: change metadata vector to chunked_fifo

### DIFF
--- a/include/seastar/core/chunked_fifo.hh
+++ b/include/seastar/core/chunked_fifo.hh
@@ -142,6 +142,7 @@ private:
         size_t _item_index = 0;
 
     protected:
+        inline basic_iterator() noexcept;
         inline explicit basic_iterator(chunk* c) noexcept;
         inline basic_iterator(chunk* c, size_t item_index) noexcept;
 
@@ -209,6 +210,12 @@ private:
     static inline size_t mask(size_t idx) noexcept;
 
 };
+
+template <typename T, size_t items_per_chunk>
+template <typename U>
+inline
+chunked_fifo<T, items_per_chunk>::basic_iterator<U>::basic_iterator() noexcept : basic_iterator(nullptr, 0) {
+}
 
 template <typename T, size_t items_per_chunk>
 template <typename U>

--- a/include/seastar/core/metrics_api.hh
+++ b/include/seastar/core/metrics_api.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/metrics.hh>
 #include <unordered_map>
 #include <seastar/core/sharded.hh>
@@ -329,7 +330,7 @@ public:
 
 using value_map = std::map<sstring, metric_family>;
 
-using metric_metadata_vector = std::vector<metric_info>;
+using metric_metadata_fifo = chunked_fifo<metric_info>;
 
 /*!
  * \brief holds a metric family metadata
@@ -340,7 +341,7 @@ using metric_metadata_vector = std::vector<metric_info>;
  */
 struct metric_family_metadata {
     metric_family_info mf;
-    metric_metadata_vector metrics;
+    metric_metadata_fifo metrics;
 };
 
 using value_vector = std::vector<metric_value>;

--- a/src/core/metrics.cc
+++ b/src/core/metrics.cc
@@ -511,7 +511,7 @@ void impl::update_metrics_if_needed() {
         _current_metrics.resize(_value_map.size());
         size_t i = 0;
         for (auto&& mf : _value_map) {
-            metric_metadata_vector metrics;
+            metric_metadata_fifo metrics;
             _current_metrics[i].clear();
             for (auto&& m : mf.second) {
                 if (m.second && m.second->is_enabled()) {

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -392,7 +392,7 @@ public:
             // does not exist, because everything is sorted by metric family name, this is fine.
             if (metadata.mf.name == name()) {
                 const mi::value_vector& values = metric_family->values[pos_in_metric_per_shard];
-                const mi::metric_metadata_vector& metrics_metadata = metadata.metrics;
+                const mi::metric_metadata_fifo& metrics_metadata = metadata.metrics;
                 for (auto&& vm : boost::combine(values, metrics_metadata)) {
                     auto& value = boost::get<0>(vm);
                     auto& metric_metadata = boost::get<1>(vm);

--- a/src/core/scollectd.cc
+++ b/src/core/scollectd.cc
@@ -400,7 +400,7 @@ void impl::arm() {
 void impl::run() {
     typedef size_t metric_family_id;
     typedef seastar::metrics::impl::value_vector::iterator value_iterator;
-    typedef seastar::metrics::impl::metric_metadata_vector::iterator metadata_iterator;
+    typedef seastar::metrics::impl::metric_metadata_fifo::iterator metadata_iterator;
     typedef std::tuple<metric_family_id, metadata_iterator, value_iterator, type_id, cpwriter> context;
 
     auto ctxt = make_lw_shared<context>();


### PR DESCRIPTION
The equivalent PR for upstream scylla is https://github.com/scylladb/seastar/pull/1741 

The vtools test passed CI as well https://github.com/redpanda-data/vtools/pull/1962

Large contiguous allocations may fail as the memory on a shard becomes fragmented over time. This can lead to over allocations on the metadata vector occurring at the call to vector.emplace_back():

```cpp
void impl::update_metrics_if_needed() {
if (_dirty) {
   _metadata = ::seastar::make_shared<metric_metadata>();

   auto mt_ref = ::seastar::make_shared<metric_metadata>();
   auto &mt = *(mt_ref.get());
   mt.reserve(_value_map.size());
   _current_metrics.resize(_value_map.size());
   size_t i = 0;
   for (auto&& mf : _value_map) {
       metric_metadata_vector metrics;
       _current_metrics[i].clear();
       for (auto&& m : mf.second) {
           if (m.second && m.second->is_enabled()) {
               metrics.emplace_back(m.second->info()); // Backtrace shows overalloc occurs here
               _current_metrics[i].emplace_back(m.second->get_function());
           }
       }
       if (!metrics.empty()) {
           mt.emplace_back(metric_family_metadata{mf.second.info(), std::move(metrics)});
           i++;
       }
   }
   _current_metrics.resize(i);
   _metadata = mt_ref;
   _dirty = false;
}
}
```

Therefore, this commit switches the metadata vector with a chunked_fifo.

Changes from force-push `43ea58e`:
- Use a delegating constructor for `chunked_fifo::basic_iterator`
- Split into two commits, one for `chunked_fifo` improvements and another for metrics changes