### PR TITLE
coroutine: fix a use-after-free in maybe_yield

### DIFF
--- a/include/seastar/coroutine/maybe_yield.hh
+++ b/include/seastar/coroutine/maybe_yield.hh
@@ -29,33 +29,17 @@ namespace seastar::coroutine {
 
 namespace internal {
 
-struct maybe_yield_awaiter final : task {
-    using coroutine_handle_t = std::coroutine_handle<void>;
-
-    coroutine_handle_t when_ready;
-    task* main_coroutine_task;
-
+struct maybe_yield_awaiter final {
     bool await_ready() const {
         return !need_preempt();
     }
 
     template <typename T>
     void await_suspend(std::coroutine_handle<T> h) {
-        when_ready = h;
-        main_coroutine_task = &h.promise(); // for waiting_task()
-        schedule(this);
+        schedule(&h.promise());
     }
 
     void await_resume() {
-    }
-
-    virtual void run_and_dispose() noexcept override {
-        when_ready.resume();
-        // No need to delete, this is allocated on the coroutine frame
-    }
-
-    virtual task* waiting_task() noexcept override {
-        return main_coroutine_task;
     }
 };
 


### PR DESCRIPTION
maybe_yield_awaiter resumes the coroutine (after it decided to suspend it) by scheduling *itself* as a task, which -- when executed -- resumes the coroutine.

The awaiter itself is (usually) allocated inside the coroutine frame, and dies after its containing co_await expression is resumed. This is a problem, because the reactor expects tasks to stay alive while they are running. To facilitate current_tasktrace(), a global pointer to the currently running task is needed. Thus, when the reactor starts executing a task, it saves a pointer to it in reactor::_current_task.

Since the awaiter task dies immediately after returning control to its parent, reactor::_current_task is left pointing to some garbage in the coroutine frame and current_tasktrace() will (most likely) segfault when used before the next task switch.

To fix this, we directly schedule the parent coroutine. Making maybe_yield_awaiter a task was an unnecessary indirection anyway.

Refs #1599. It's the same kind of bug.

Fixes #1759

(cherry picked from commit 7fe5bdd6d85b6f3a57491882a4fbd809f54956f0)