### PR TITLE
epoll: Avoid spinning on aborted connections

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -857,10 +857,12 @@ reactor_backend_epoll::wait_and_process(int timeout, const sigset_t* active_sigm
             _steady_clock_timer_deadline = {};
             continue;
         }
+        bool has_error = false;
         if (evt.events & (EPOLLHUP | EPOLLERR)) {
             // treat the events as required events when error occurs, let
             // send/recv/accept/connect handle the specific error.
             evt.events = pfd->events_requested;
+            has_error = true;
         }
         auto events = evt.events & (EPOLLIN | EPOLLOUT | EPOLLRDHUP);
         auto events_to_remove = events & ~pfd->events_requested;
@@ -881,6 +883,18 @@ reactor_backend_epoll::wait_and_process(int timeout, const sigset_t* active_sigm
             evt.events = pfd->events_epoll;
             auto op = evt.events ? EPOLL_CTL_MOD : EPOLL_CTL_DEL;
             ::epoll_ctl(_epollfd.get(), op, pfd->fd.get(), &evt);
+        }
+        else if (has_error && pfd->events_requested == 0) {
+            // In case we got an error and we are not interested in any events
+            // anymore, remove the fd from the epoll set. Otherwise due to the
+            // above logic of setting evt.events to pfd->events_requested (0)
+            // and subsequent calculation of events_to_remove, we would never
+            // remove the fd from the epoll set. Due to running in level
+            // triggered mode this would then cause repeated wake ups and
+            // spinning until the fd is closed and thereby removed from the
+            // epoll set.
+            pfd->events_epoll = 0;
+            ::epoll_ctl(_epollfd.get(), EPOLL_CTL_DEL, pfd->fd.get(), nullptr);
         }
     }
     return nr;


### PR DESCRIPTION
Using the epoll backend and having a non-closed socket that got terminated
with either EPOLLHUP|EPOLLERR under the hood but isn't closed yet can lead to
busy spinning in the reactor at 100%.

It's caused by the following scenario:

 - epoll_pwait returns an event for a socket with EPOLLIN|EPOLLHUP (or
   EPOLLOUT in a different respective case)
 - We enter the error branch and set evt.events. This doesn't make much
   difference at this point as pfd->events_requested is still equal to
   EPOLLIN
 - events_to_remove is calculated to 0
 - complete_epoll_event is called setting pfd->events_requested to 0
 - The loop concludes without removing the socket from the epoll set as
   we calculate events_to_remove before changing it. I think this is
   intended to avoid unneeded syscalls in the good case (so usually only
   receiving an event when not waiting for it will remove the socket from
   the set)
 - Given we run in level triggered mode epoll_wait again returns with
   EPOLLIN|EPOLLHUP for our socket
 - This time around in the error branch we set evt.events to 0
 - This causes events_to_remove again to be calculated to 0 even though
   pfd->events_requested is 0 as well
 - Above continues until the socket is eventually closed and hence
   implicitly removed from the epoll set

This patch prevents this from happening by pro-actively removing the fd
from the epoll set once we have received an error and are no longer
waiting for any events on the socket.

Note this should be relatively safe in any case. In case we ever get
interested in events again we would just add it back.