### PR TITLE
tls: Optionally skip client EOF wait

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -330,9 +330,14 @@ namespace tls {
     ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
     /// @}
 
-    /** Wraps an existing connection in SSL/TLS. */
+    /** 
+     * Wraps an existing connection in SSL/TLS.
+     *
+     * \param wait_for_eof Optionally indicate to the client if it should wait for an EOF from the server
+     * after sending the BYE message. By default, the wait is hardcoded to 10 seconds.
+     */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {});
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, bool wait_for_eof = true);
     future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 


### PR DESCRIPTION
This commit extends the `tls::wrap_client` interface with an optional param which indicates to the sessions that it should not wait for an EOF after sending the BYE message.

Badly behaved servers will not send the expected EOF message. Clients that call `wait_input_shutdown` on the connected socket will hang for 10 seconds in that case.

The previous default behaviour has been preserved and clients should always wait for EOF if the intend to re-use the connection.