### PR TITLE
http: fix deprecated warning, reply -> http::reply

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -48,7 +48,7 @@ public:
      * a base_exception with only a _status is specifying a string that may be wrapped
      * in e.g. a json_exception.
      */
-    base_exception(const std::string& msg, reply::status_type status, const std::string &content_type)
+    base_exception(const std::string& msg, http::reply::status_type status, const std::string &content_type)
             : _msg(msg), _status(status), _content_type(content_type) {
     }
 
@@ -79,7 +79,7 @@ private:
  */
 class redirect_exception : public base_exception {
 public:
-    redirect_exception(const std::string& url, reply::status_type status = reply::status_type::moved_permanently)
+    redirect_exception(const std::string& url, http::reply::status_type status = http::reply::status_type::moved_permanently)
             : base_exception("", status), url(url) {
     }
     std::string url;

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -110,7 +110,7 @@ public:
     future<> start_response();
 
     future<bool> generate_reply(std::unique_ptr<http::request> req);
-    void generate_error_reply_and_close(std::unique_ptr<http::request> req, reply::status_type status, const sstring& msg, const sstring &content_type={});
+    void generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg, const sstring &content_type={});
 
     future<> write_body();
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -201,7 +201,7 @@ set_request_content(std::unique_ptr<http::request> req, input_stream<char>* cont
     }
 }
 
-void connection::generate_error_reply_and_close(std::unique_ptr<http::request> req, reply::status_type status, const sstring& msg, const sstring &content_type) {
+void connection::generate_error_reply_and_close(std::unique_ptr<http::request> req, http::reply::status_type status, const sstring& msg, const sstring &content_type) {
     auto resp = std::make_unique<http::reply>();
     // TODO: Handle HTTP/2.0 when it releases
     resp->set_version(req->_version);


### PR DESCRIPTION
reply was moved to http::reply namespace, this pr fixes some params that were not changed and were triggering a deprecation message