### PR TITLE
[v23.3.x] chore: sync tls options with upstream

### DIFF
--- a/demos/tls_simple_client_demo.cc
+++ b/demos/tls_simple_client_demo.cc
@@ -89,11 +89,11 @@ int main(int ac, char** av) {
             return net::dns::get_host_by_name(addr).then([=](net::hostent e) {
                 ipv4_addr ia(e.addr_list.front(), port);
 
-                sstring name;
+                tls::tls_options options;
                 if (check) {
-                    name = server_name.empty() ? e.names.front() : server_name;
+                    options.server_name = server_name.empty() ? e.names.front() : server_name;
                 }
-                return tls::connect(certs, ia, name).then([=](::connected_socket s) {
+                return tls::connect(certs, ia, options).then([=](::connected_socket s) {
                     auto strms = ::make_lw_shared<streams>(std::move(s));
                     auto range = boost::irange(size_t(0), i);
                     return do_for_each(range, [=](auto) {

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -309,6 +309,8 @@ namespace tls {
     struct tls_options {
         /// \brief whether to wait for EOF from server on session termination
         bool wait_for_eof_on_shutdown = true;
+        /// \brief server name to be used for the SNI TLS extension
+        sstring server_name = {};
     };
 
     /**
@@ -317,11 +319,28 @@ namespace tls {
      * Typically these should contain enough information
      * to validate the remote certificate (i.e. trust info).
      *
-     * \param name An optional expected server name for the remote end point
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
      */
     /// @{
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name = {});
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name = {});
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name);
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name);
+    /// @}
+
+    /**
+     * Creates a TLS client connection using the default network stack and the
+     * supplied credentials.
+     * Typically these should contain enough information
+     * to validate the remote certificate (i.e. trust info).
+     *
+     * \param options Optional additional session configuration
+     */
+    /// @{
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, tls_options option = {});
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, tls_options options = {});
     /// @}
 
     /**
@@ -330,10 +349,38 @@ namespace tls {
      * Typically these should contain enough information
      * to validate the remote certificate (i.e. trust info).
      *
-     * \param name An optional expected server name for the remote end point
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
      */
     /// @{
-    ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
+    [[deprecated("Use overload with tls_options parameter")]]
+    ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name);
+    /// @}
+
+    /**
+     * Creates a socket through which a TLS client connection can be created,
+     * using the default network stack and the supplied credentials.
+     * Typically these should contain enough information
+     * to validate the remote certificate (i.e. trust info).
+     *
+     * \param options Optional additional session configuration
+     */
+    /// @{
+    ::seastar::socket socket(shared_ptr<certificate_credentials>, tls_options options = {});
+    /// @}
+
+    /**
+     * Wraps an existing connection in SSL/TLS.
+     *
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
+     */
+    /// @{
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name);
+    future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 
     /**
@@ -342,8 +389,7 @@ namespace tls {
      * \param options Optional additional session configuration
      */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, tls_options options = {});
-    future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, tls_options options = {});
     /// @}
 
     /**

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -305,12 +305,6 @@ namespace tls {
         sstring _priority;
     };
 
-    struct tls_options {
-        // Optionally indicate to the client if it should wait for an EOF from the server
-        // after sending the BYE message. By default, the wait is hardcoded to 10 seconds.
-        bool wait_for_eof_on_shutdown = true;
-    };
-
     /**
      * Creates a TLS client connection using the default network stack and the
      * supplied credentials.
@@ -336,13 +330,9 @@ namespace tls {
     ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
     /// @}
 
-    /**
-     * Wraps an existing connection in SSL/TLS.
-     *
-     * \param options Optional additional session configuration
-     */
+    /** Wraps an existing connection in SSL/TLS. */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, std::optional<tls_options> options = std::nullopt);
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {});
     future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -305,6 +305,12 @@ namespace tls {
         sstring _priority;
     };
 
+    /// TLS configuration options
+    struct tls_options {
+        /// \brief whether to wait for EOF from server on session termination
+        bool wait_for_eof_on_shutdown = true;
+    };
+
     /**
      * Creates a TLS client connection using the default network stack and the
      * supplied credentials.
@@ -330,9 +336,13 @@ namespace tls {
     ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
     /// @}
 
-    /** Wraps an existing connection in SSL/TLS. */
+    /**
+     * Wraps an existing connection in SSL/TLS.
+     *
+     * \param options Optional additional session configuration
+     */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {});
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, tls_options options = {});
     future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -208,7 +208,7 @@ public:
     {
     }
     virtual future<connected_socket> make() override {
-        return tls::connect(_creds, _addr, _host);
+        return tls::connect(_creds, _addr, tls::tls_options{.server_name = _host});
     }
 };
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1001,10 +1001,10 @@ public:
     };
 
     session(type t, shared_ptr<tls::certificate_credentials> creds,
-            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { })
+            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { }, tls_options options = {})
             : _type(t), _sock(std::move(sock)), _creds(creds->_impl), _hostname(
                     std::move(name)), _in(_sock->source()), _out(_sock->sink()),
-                    _in_sem(1), _out_sem(1), _output_pending(
+                    _in_sem(1), _out_sem(1), _options(options), _output_pending(
                     make_ready_future<>()), _session([t] {
                 gnutls_session_t session;
                 gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
@@ -1047,9 +1047,10 @@ public:
 #endif
     }
     session(type t, shared_ptr<certificate_credentials> creds,
-            connected_socket sock, sstring name = { })
+            connected_socket sock, sstring name = { },
+            tls_options options = {})
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
-                    std::move(name)) {
+                    std::move(name), options) {
     }
 
     ~session() {
@@ -1467,6 +1468,10 @@ public:
         return wait_for_output();
     }
     future<> wait_for_eof() {
+        if (!_options.wait_for_eof_on_shutdown) {
+            return make_ready_future();
+        }
+
         // read records until we get an eof alert
         // since this call could time out, we must not ac
         return with_semaphore(_in_sem, 1, [this] {
@@ -1685,6 +1690,8 @@ private:
 
     semaphore _in_sem, _out_sem;
 
+    tls_options _options;
+
     bool _eof = false;
     bool _shutdown = false;
     bool _connected = false;
@@ -1889,8 +1896,8 @@ socket tls::socket(shared_ptr<certificate_credentials> cred, sstring name) {
     return ::seastar::socket(std::make_unique<tls_socket_impl>(std::move(cred), std::move(name)));
 }
 
-future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
-    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name)));
+future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name, tls_options options) {
+    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name), options));
     connected_socket sock(std::make_unique<tls_connected_socket_impl>(std::move(sess)));
     return make_ready_future<connected_socket>(std::move(sock));
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1001,10 +1001,10 @@ public:
     };
 
     session(type t, shared_ptr<tls::certificate_credentials> creds,
-            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { }, std::optional<tls_options> options = std::nullopt)
+            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { })
             : _type(t), _sock(std::move(sock)), _creds(creds->_impl), _hostname(
                     std::move(name)), _in(_sock->source()), _out(_sock->sink()),
-                    _in_sem(1), _out_sem(1), _options(options.value_or(tls_options{})), _output_pending(
+                    _in_sem(1), _out_sem(1), _output_pending(
                     make_ready_future<>()), _session([t] {
                 gnutls_session_t session;
                 gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
@@ -1047,10 +1047,9 @@ public:
 #endif
     }
     session(type t, shared_ptr<certificate_credentials> creds,
-            connected_socket sock, sstring name = { },
-            std::optional<tls_options> options = std::nullopt)
+            connected_socket sock, sstring name = { })
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
-                    std::move(name), options) {
+                    std::move(name)) {
     }
 
     ~session() {
@@ -1468,10 +1467,6 @@ public:
         return wait_for_output();
     }
     future<> wait_for_eof() {
-        if (!_options.wait_for_eof_on_shutdown) {
-            return make_ready_future();
-        }
-
         // read records until we get an eof alert
         // since this call could time out, we must not ac
         return with_semaphore(_in_sem, 1, [this] {
@@ -1690,8 +1685,6 @@ private:
 
     semaphore _in_sem, _out_sem;
 
-    tls_options _options;
-
     bool _eof = false;
     bool _shutdown = false;
     bool _connected = false;
@@ -1896,8 +1889,8 @@ socket tls::socket(shared_ptr<certificate_credentials> cred, sstring name) {
     return ::seastar::socket(std::make_unique<tls_socket_impl>(std::move(cred), std::move(name)));
 }
 
-future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name, std::optional<tls_options> options) {
-    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name), options));
+future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
+    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name)));
     connected_socket sock(std::make_unique<tls_connected_socket_impl>(std::move(sess)));
     return make_ready_future<connected_socket>(std::move(sock));
 }

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1434,3 +1434,59 @@ SEASTAR_THREAD_TEST_CASE(test_alt_names) {
 
 }
 
+SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
+    tls::credentials_builder b;
+
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_client_auth(tls::client_auth::REQUIRE);
+
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    ::listen_options opts;
+    opts.reuse_address = true;
+    opts.set_fixed_cpu(this_shard_id());
+
+    auto addr = ::make_ipv4_address({0x7f000001, 4712});
+    auto server = tls::listen(serv, addr, opts);
+
+    {
+        // Initiate a connection while specifying that it should not wait for eof on shutdown.
+        auto sa = server.accept();
+        auto c = engine().connect(addr).get();
+        auto c_tls = tls::wrap_client(creds, std::move(c), sstring{},
+                                      tls::tls_options{.wait_for_eof_on_shutdown = false}).get();
+        auto s = sa.get();
+
+        auto in = s.connection.input();
+        auto out = c_tls.output();
+
+        // Write some data in the socket to handshake.
+        out.write("apa").get();
+        auto f = out.flush();
+        auto buf = in.read().get0();
+        f.get();
+        BOOST_CHECK(sstring(buf.begin(), buf.end()) == "apa");
+
+        // Prevent the server from reading from the connection.
+        // This ensures that it will miss the bye message and not
+        // reply with an eof.
+        server.abort_accept();
+
+        // Initiate closing of the TLS session
+        c_tls.shutdown_input();
+        c_tls.shutdown_output();
+
+        // Ensure that the session is closed promptly. When wait_for_eof_on_shutdown is not
+        // specified, the call to wait_input_shutdown will hang for 10 seconds waiting for
+        // and eof from the server.
+        try {
+            with_timeout(std::chrono::steady_clock::now() + 1s, c_tls.wait_input_shutdown()).get();
+        } catch (timed_out_error&) {
+            BOOST_FAIL("Timed out while waiting for input shutdown."
+                       "This indicates the EOF wait was not skipped");
+        }
+    }
+}
+

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -67,7 +67,7 @@ using namespace seastar;
 
 static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> certs, socket_address addr, const sstring& name = {}) {
     return repeat_until_value([=]() mutable {
-        return tls::connect(certs, addr, name).then([](connected_socket s) {
+        return tls::connect(certs, addr, tls::tls_options{.server_name = name}).then([](connected_socket s) {
             return do_with(std::move(s), [](connected_socket& s) {
                 return do_with(s.output(), [&s](auto& os) {
                     static const sstring msg("GET / HTTP/1.0\r\n\r\n");
@@ -592,7 +592,7 @@ static future<> run_echo_test(sstring message,
             }
             return server->invoke_on_all(&echoserver::listen, addr, crt, key, ca, server_trust);
         }).then([=] {
-            return tls::connect(certs, addr, name).then([loops, msg, do_read](::connected_socket s) {
+            return tls::connect(certs, addr, tls::tls_options{.server_name=name}).then([loops, msg, do_read](::connected_socket s) {
                 auto strms = ::make_lw_shared<streams>(std::move(s));
                 auto range = boost::irange(0, loops);
                 return do_for_each(range, [strms, msg](auto) {
@@ -1455,7 +1455,7 @@ SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
         // Initiate a connection while specifying that it should not wait for eof on shutdown.
         auto sa = server.accept();
         auto c = engine().connect(addr).get();
-        auto c_tls = tls::wrap_client(creds, std::move(c), sstring{},
+        auto c_tls = tls::wrap_client(creds, std::move(c),
                                       tls::tls_options{.wait_for_eof_on_shutdown = false}).get();
         auto s = sa.get();
 


### PR DESCRIPTION
We merged https://github.com/redpanda-data/seastar/pull/67 into the v23.3.x before the [upstream PR](https://github.com/scylladb/seastar/pull/1797) was merged. Now that upstream has merged, revert the original
PR and cherry pick from upstream. 
