### PR TITLE
[v23.2.x] chore: sync tls options with upstream

### DIFF
--- a/demos/tls_simple_client_demo.cc
+++ b/demos/tls_simple_client_demo.cc
@@ -89,11 +89,11 @@ int main(int ac, char** av) {
             return net::dns::get_host_by_name(addr).then([=](net::hostent e) {
                 ipv4_addr ia(e.addr_list.front(), port);
 
-                sstring name;
+                tls::tls_options options;
                 if (check) {
-                    name = server_name.empty() ? e.names.front() : server_name;
+                    options.server_name = server_name.empty() ? e.names.front() : server_name;
                 }
-                return tls::connect(certs, ia, name).then([=](::connected_socket s) {
+                return tls::connect(certs, ia, options).then([=](::connected_socket s) {
                     auto strms = ::make_lw_shared<streams>(std::move(s));
                     auto range = boost::irange(size_t(0), i);
                     return do_for_each(range, [=](auto) {

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -305,6 +305,8 @@ namespace tls {
     struct tls_options {
         /// \brief whether to wait for EOF from server on session termination
         bool wait_for_eof_on_shutdown = true;
+        /// \brief server name to be used for the SNI TLS extension
+        sstring server_name = {};
     };
 
     /**
@@ -313,11 +315,28 @@ namespace tls {
      * Typically these should contain enough information
      * to validate the remote certificate (i.e. trust info).
      *
-     * \param name An optional expected server name for the remote end point
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
      */
     /// @{
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name = {});
-    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name = {});
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, sstring name);
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, sstring name);
+    /// @}
+
+    /**
+     * Creates a TLS client connection using the default network stack and the
+     * supplied credentials.
+     * Typically these should contain enough information
+     * to validate the remote certificate (i.e. trust info).
+     *
+     * \param options Optional additional session configuration
+     */
+    /// @{
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, tls_options option = {});
+    future<connected_socket> connect(shared_ptr<certificate_credentials>, socket_address, socket_address local, tls_options options = {});
     /// @}
 
     /**
@@ -326,10 +345,38 @@ namespace tls {
      * Typically these should contain enough information
      * to validate the remote certificate (i.e. trust info).
      *
-     * \param name An optional expected server name for the remote end point
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
      */
     /// @{
-    ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
+    [[deprecated("Use overload with tls_options parameter")]]
+    ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name);
+    /// @}
+
+    /**
+     * Creates a socket through which a TLS client connection can be created,
+     * using the default network stack and the supplied credentials.
+     * Typically these should contain enough information
+     * to validate the remote certificate (i.e. trust info).
+     *
+     * \param options Optional additional session configuration
+     */
+    /// @{
+    ::seastar::socket socket(shared_ptr<certificate_credentials>, tls_options options = {});
+    /// @}
+
+    /**
+     * Wraps an existing connection in SSL/TLS.
+     *
+     * ATTN: The method is going to be deprecated
+     *
+     * \param name The expected server name for the remote end point
+     */
+    /// @{
+    [[deprecated("Use overload with tls_options parameter")]]
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name);
+    future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 
     /**
@@ -338,8 +385,7 @@ namespace tls {
      * \param options Optional additional session configuration
      */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, tls_options options = {});
-    future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, tls_options options = {});
     /// @}
 
     /**

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -387,6 +387,25 @@ namespace tls {
      * If the socket is not a TLS socket an exception will be thrown.
     */
     future<std::vector<subject_alt_name>> get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types = {});
+
+    std::ostream& operator<<(std::ostream&, const subject_alt_name::value_type&);
+    std::ostream& operator<<(std::ostream&, const subject_alt_name&);
+
+    /**
+     * Alt name to string. 
+     * Note: because naming of alternative names is inconsistent between tools,
+     * and because openssl is probably more popular when creating certs anyway,
+     * this routine will be inconsistent with both gnutls and openssl (though more
+     * in line with the latter) and name the constants as follows:
+     * 
+     * dnsname: "DNS"
+     * rfc822name: "EMAIL"
+     * uri: "URI"
+     * ipaddress "IP"
+     * othername: "OTHERNAME"
+     * dn: "DIRNAME"
+    */
+    std::ostream& operator<<(std::ostream&, subject_alt_name_type);
 }
 }
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -300,12 +300,6 @@ namespace tls {
         sstring _priority;
     };
 
-    struct tls_options {
-        // Optionally indicate to the client if it should wait for an EOF from the server
-        // after sending the BYE message. By default, the wait is hardcoded to 10 seconds.
-        bool wait_for_eof_on_shutdown = true;
-    };
-
     /**
      * Creates a TLS client connection using the default network stack and the
      * supplied credentials.
@@ -331,13 +325,9 @@ namespace tls {
     ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
     /// @}
 
-    /**
-     * Wraps an existing connection in SSL/TLS.
-     *
-     * \param options Optional additional session configuration
-     */
+    /** Wraps an existing connection in SSL/TLS. */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, std::optional<tls_options> options = std::nullopt);
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {});
     future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -301,6 +301,12 @@ namespace tls {
         sstring _priority;
     };
 
+    /// TLS configuration options
+    struct tls_options {
+        /// \brief whether to wait for EOF from server on session termination
+        bool wait_for_eof_on_shutdown = true;
+    };
+
     /**
      * Creates a TLS client connection using the default network stack and the
      * supplied credentials.
@@ -326,9 +332,13 @@ namespace tls {
     ::seastar::socket socket(shared_ptr<certificate_credentials>, sstring name = {});
     /// @}
 
-    /** Wraps an existing connection in SSL/TLS. */
+    /**
+     * Wraps an existing connection in SSL/TLS.
+     *
+     * \param options Optional additional session configuration
+     */
     /// @{
-    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {});
+    future<connected_socket> wrap_client(shared_ptr<certificate_credentials>, connected_socket&&, sstring name = {}, tls_options options = {});
     future<connected_socket> wrap_server(shared_ptr<server_credentials>, connected_socket&&);
     /// @}
 

--- a/src/http/client.cc
+++ b/src/http/client.cc
@@ -177,7 +177,7 @@ public:
     {
     }
     virtual future<connected_socket> make() override {
-        return tls::connect(_creds, _addr, _host);
+        return tls::connect(_creds, _addr, tls::tls_options{.server_name = _host});
     }
 };
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -982,10 +982,10 @@ public:
     };
 
     session(type t, shared_ptr<tls::certificate_credentials> creds,
-            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { }, tls_options options = {})
-            : _type(t), _sock(std::move(sock)), _creds(creds->_impl), _hostname(
-                    std::move(name)), _in(_sock->source()), _out(_sock->sink()),
-                    _in_sem(1), _out_sem(1), _options(options), _output_pending(
+            std::unique_ptr<net::connected_socket_impl> sock, tls_options options = {})
+            : _type(t), _sock(std::move(sock)), _creds(creds->_impl),
+                    _in(_sock->source()), _out(_sock->sink()),
+                    _in_sem(1), _out_sem(1), _options(std::move(options)), _output_pending(
                     make_ready_future<>()), _session([t] {
                 gnutls_session_t session;
                 gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
@@ -1028,10 +1028,10 @@ public:
 #endif
     }
     session(type t, shared_ptr<certificate_credentials> creds,
-            connected_socket sock, sstring name = { },
+            connected_socket sock,
             tls_options options = {})
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
-                    std::move(name), options) {
+                      std::move(options)) {
     }
 
     ~session() {
@@ -1075,8 +1075,8 @@ public:
         if (_connected) {
             return make_ready_future<>();
         }
-        if (_type == type::CLIENT && !_hostname.empty()) {
-            gnutls_server_name_set(*this, GNUTLS_NAME_DNS, _hostname.data(), _hostname.size());
+        if (_type == type::CLIENT && !_options.server_name.empty()) {
+            gnutls_server_name_set(*this, GNUTLS_NAME_DNS, _options.server_name.data(), _options.server_name.size());
         }
         try {
             auto res = gnutls_handshake(*this);
@@ -1198,8 +1198,8 @@ public:
 
     void verify() {
         unsigned int status;
-        auto res = gnutls_certificate_verify_peers3(*this, _type != type::CLIENT || _hostname.empty()
-                        ? nullptr : _hostname.c_str(), &status);
+        auto res = gnutls_certificate_verify_peers3(*this, _type != type::CLIENT || _options.server_name.empty()
+                        ? nullptr : _options.server_name.c_str(), &status);
         if (res == GNUTLS_E_NO_CERTIFICATE_FOUND && _type != type::CLIENT && _creds->get_client_auth() != client_auth::REQUIRE) {
             return;
         }
@@ -1664,7 +1664,6 @@ private:
 
     std::unique_ptr<net::connected_socket_impl> _sock;
     shared_ptr<tls::certificate_credentials::impl> _creds;
-    const sstring _hostname;
     data_source _in;
     data_sink _out;
 
@@ -1827,15 +1826,15 @@ private:
 
 class tls_socket_impl : public net::socket_impl {
     shared_ptr<certificate_credentials> _cred;
-    sstring _name;
+    tls_options _options;
     ::seastar::socket _socket;
 public:
-    tls_socket_impl(shared_ptr<certificate_credentials> cred, sstring name)
-            : _cred(cred), _name(std::move(name)), _socket(make_socket()) {
+    tls_socket_impl(shared_ptr<certificate_credentials> cred, tls_options options)
+            : _cred(cred), _options(std::move(options)), _socket(make_socket()) {
     }
     virtual future<connected_socket> connect(socket_address sa, socket_address local, transport proto = transport::TCP) override {
-        return _socket.connect(sa, local, proto).then([cred = std::move(_cred), name = std::move(_name)](connected_socket s) mutable {
-            return wrap_client(cred, std::move(s), std::move(name));
+        return _socket.connect(sa, local, proto).then([cred = std::move(_cred), options = std::move(_options)](connected_socket s) mutable {
+            return wrap_client(cred, std::move(s), std::move(options));
         });
     }
     void set_reuseaddr(bool reuseaddr) override {
@@ -1861,23 +1860,43 @@ data_sink tls::tls_connected_socket_impl::sink() {
 
 
 future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, socket_address sa, sstring name) {
-    return engine().connect(sa).then([cred = std::move(cred), name = std::move(name)](connected_socket s) mutable {
-        return wrap_client(cred, std::move(s), std::move(name));
-    });
+    tls_options options{.server_name = std::move(name)};
+    return connect(std::move(cred), std::move(sa), std::move(options));
 }
 
 future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, socket_address sa, socket_address local, sstring name) {
-    return engine().connect(sa, local).then([cred = std::move(cred), name = std::move(name)](connected_socket s) mutable {
-        return wrap_client(cred, std::move(s), std::move(name));
+    tls_options options{.server_name = std::move(name)};
+    return connect(std::move(cred), std::move(sa), std::move(local), std::move(options));
+}
+
+future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, socket_address sa, tls_options options) {
+    return engine().connect(sa).then([cred = std::move(cred), options = std::move(options)](connected_socket s) mutable {
+        return wrap_client(std::move(cred), std::move(s), std::move(options));
+    });
+}
+
+future<connected_socket> tls::connect(shared_ptr<certificate_credentials> cred, socket_address sa, socket_address local, tls_options options) {
+    return engine().connect(sa, local).then([cred = std::move(cred), options = std::move(options)](connected_socket s) mutable {
+        return wrap_client(std::move(cred), std::move(s), std::move(options));
     });
 }
 
 socket tls::socket(shared_ptr<certificate_credentials> cred, sstring name) {
-    return ::seastar::socket(std::make_unique<tls_socket_impl>(std::move(cred), std::move(name)));
+    tls_options options{.server_name = std::move(name)};
+    return tls::socket(std::move(cred), std::move(options));
 }
 
-future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name, tls_options options) {
-    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name), options));
+socket tls::socket(shared_ptr<certificate_credentials> cred, tls_options options) {
+    return ::seastar::socket(std::make_unique<tls_socket_impl>(std::move(cred), std::move(options)));
+}
+
+future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
+    tls_options options{.server_name = std::move(name)};
+    return wrap_client(std::move(cred), std::move(s), std::move(options));
+}
+
+future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, tls_options options) {
+    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s),  options));
     connected_socket sock(std::make_unique<tls_connected_socket_impl>(std::move(sess)));
     return make_ready_future<connected_socket>(std::move(sock));
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -982,10 +982,10 @@ public:
     };
 
     session(type t, shared_ptr<tls::certificate_credentials> creds,
-            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { }, std::optional<tls_options> options = std::nullopt)
+            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { })
             : _type(t), _sock(std::move(sock)), _creds(creds->_impl), _hostname(
                     std::move(name)), _in(_sock->source()), _out(_sock->sink()),
-                    _in_sem(1), _out_sem(1), _options(options.value_or(tls_options{})), _output_pending(
+                    _in_sem(1), _out_sem(1), _output_pending(
                     make_ready_future<>()), _session([t] {
                 gnutls_session_t session;
                 gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
@@ -1028,10 +1028,9 @@ public:
 #endif
     }
     session(type t, shared_ptr<certificate_credentials> creds,
-            connected_socket sock, sstring name = { },
-            std::optional<tls_options> options = std::nullopt)
+            connected_socket sock, sstring name = { })
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
-                    std::move(name), options) {
+                    std::move(name)) {
     }
 
     ~session() {
@@ -1448,10 +1447,6 @@ public:
         return wait_for_output();
     }
     future<> wait_for_eof() {
-        if (!_options.wait_for_eof_on_shutdown) {
-            return make_ready_future();
-        }
-
         // read records until we get an eof alert
         // since this call could time out, we must not ac
         return with_semaphore(_in_sem, 1, [this] {
@@ -1569,8 +1564,6 @@ private:
     data_sink _out;
 
     semaphore _in_sem, _out_sem;
-
-    tls_options _options;
 
     bool _eof = false;
     bool _shutdown = false;
@@ -1773,8 +1766,8 @@ socket tls::socket(shared_ptr<certificate_credentials> cred, sstring name) {
     return ::seastar::socket(std::make_unique<tls_socket_impl>(std::move(cred), std::move(name)));
 }
 
-future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name, std::optional<tls_options> options) {
-    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name), options));
+future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
+    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name)));
     connected_socket sock(std::make_unique<tls_connected_socket_impl>(std::move(sess)));
     return make_ready_future<connected_socket>(std::move(sock));
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -982,10 +982,10 @@ public:
     };
 
     session(type t, shared_ptr<tls::certificate_credentials> creds,
-            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { })
+            std::unique_ptr<net::connected_socket_impl> sock, sstring name = { }, tls_options options = {})
             : _type(t), _sock(std::move(sock)), _creds(creds->_impl), _hostname(
                     std::move(name)), _in(_sock->source()), _out(_sock->sink()),
-                    _in_sem(1), _out_sem(1), _output_pending(
+                    _in_sem(1), _out_sem(1), _options(options), _output_pending(
                     make_ready_future<>()), _session([t] {
                 gnutls_session_t session;
                 gtls_chk(gnutls_init(&session, GNUTLS_NONBLOCK|uint32_t(t)));
@@ -1028,9 +1028,10 @@ public:
 #endif
     }
     session(type t, shared_ptr<certificate_credentials> creds,
-            connected_socket sock, sstring name = { })
+            connected_socket sock, sstring name = { },
+            tls_options options = {})
             : session(t, std::move(creds), net::get_impl::get(std::move(sock)),
-                    std::move(name)) {
+                    std::move(name), options) {
     }
 
     ~session() {
@@ -1447,6 +1448,10 @@ public:
         return wait_for_output();
     }
     future<> wait_for_eof() {
+        if (!_options.wait_for_eof_on_shutdown) {
+            return make_ready_future();
+        }
+
         // read records until we get an eof alert
         // since this call could time out, we must not ac
         return with_semaphore(_in_sem, 1, [this] {
@@ -1665,6 +1670,8 @@ private:
 
     semaphore _in_sem, _out_sem;
 
+    tls_options _options;
+
     bool _eof = false;
     bool _shutdown = false;
     bool _connected = false;
@@ -1869,8 +1876,8 @@ socket tls::socket(shared_ptr<certificate_credentials> cred, sstring name) {
     return ::seastar::socket(std::make_unique<tls_socket_impl>(std::move(cred), std::move(name)));
 }
 
-future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name) {
-    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name)));
+future<connected_socket> tls::wrap_client(shared_ptr<certificate_credentials> cred, connected_socket&& s, sstring name, tls_options options) {
+    session::session_ref sess(make_lw_shared<session>(session::type::CLIENT, std::move(cred), std::move(s), std::move(name), options));
     connected_socket sock(std::make_unique<tls_connected_socket_impl>(std::move(sess)));
     return make_ready_future<connected_socket>(std::move(sock));
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1912,4 +1912,27 @@ future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connect
     return get_tls_socket(socket)->get_alt_name_information(std::move(types));
 }
 
+std::ostream& tls::operator<<(std::ostream& os, subject_alt_name_type type) {
+    switch (type) {
+        case subject_alt_name_type::dnsname: os << "DNS"; break;
+        case subject_alt_name_type::rfc822name: os << "EMAIL"; break;
+        case subject_alt_name_type::uri: os << "URI"; break;
+        case subject_alt_name_type::ipaddress: os << "IP"; break;
+        case subject_alt_name_type::othername: os << "OTHERNAME"; break;
+        case subject_alt_name_type::dn: os << "DIRNAME"; break;
+        default: break;
+    }
+    return os;
+}
+
+std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name::value_type& v) {
+    std::visit([&](auto& vv) { os << vv; }, v);
+    return os;
+}
+
+std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name& a) {
+    return os << a.type << "=" << a.value;
+}
+
+
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -504,6 +504,18 @@ function(seastar_add_certgen name)
   if (NOT CERT_EMAIL)
     set(CERT_EMAIL postmaster@${CERT_DOMAIN})
   endif()
+  if (NOT CERT_ALT_EMAIL_1)
+    set(CERT_ALT_EMAIL_1 alt1@${CERT_DOMAIN})
+  endif()
+  if (NOT CERT_ALT_EMAIL_2)
+    set(CERT_ALT_EMAIL_2 alt2@${CERT_DOMAIN})
+  endif()
+  if (NOT CERT_ALT_IP_1)
+    set(CERT_ALT_IP_1 127.0.0.1)
+  endif()
+  if (NOT CERT_ALT_DNS)
+    set(CERT_ALT_DNS ${CERT_COMMON})
+  endif()
   if (NOT CERT_WIDTH)
     set(CERT_WIDTH 4096)
   endif()
@@ -536,7 +548,7 @@ function(seastar_add_certgen name)
   )
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_REQ}"
     COMMAND ${OPENSSL} req -new -key ${CERT_PRIVKEY} -out ${CERT_REQ} -config ${CERT_NAME}.cfg
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_PRIVKEY}"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_PRIVKEY}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
@@ -546,13 +558,14 @@ function(seastar_add_certgen name)
   )
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}"
     COMMAND ${OPENSSL} req -x509 -new -nodes -key ${CERT_CAPRIVKEY} -days ${CERT_DAYS} -config ${CERT_NAME}.cfg -out ${CERT_CAROOT}
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAPRIVKEY}"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAPRIVKEY}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 
+  
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CERT}"
-    COMMAND ${OPENSSL} x509 -req -in ${CERT_REQ} -CA ${CERT_CAROOT} -CAkey ${CERT_CAPRIVKEY} -CAcreateserial -out ${CERT_CERT} -days ${CERT_DAYS}
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_REQ}"  "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}"
+    COMMAND ${OPENSSL} x509 -req -in ${CERT_REQ} -CA ${CERT_CAROOT} -CAkey ${CERT_CAPRIVKEY} -CAcreateserial -out ${CERT_CERT} -days ${CERT_DAYS} -extensions req_ext -extfile ${CERT_NAME}.cfg
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_REQ}"  "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 

--- a/tests/unit/cert.cfg.in
+++ b/tests/unit/cert.cfg.in
@@ -21,3 +21,6 @@ basicConstraints = CA:true
 # Extensions to add to a certificate request
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[req_ext]
+subjectAltName=email:@CERT_ALT_EMAIL_1@,email:@CERT_ALT_EMAIL_2@,IP:@CERT_ALT_IP_1@,DNS:@CERT_ALT_DNS@

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1434,3 +1434,59 @@ SEASTAR_THREAD_TEST_CASE(test_alt_names) {
 
 }
 
+SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
+    tls::credentials_builder b;
+
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_client_auth(tls::client_auth::REQUIRE);
+
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    ::listen_options opts;
+    opts.reuse_address = true;
+    opts.set_fixed_cpu(this_shard_id());
+
+    auto addr = ::make_ipv4_address({0x7f000001, 4712});
+    auto server = tls::listen(serv, addr, opts);
+
+    {
+        // Initiate a connection while specifying that it should not wait for eof on shutdown.
+        auto sa = server.accept();
+        auto c = engine().connect(addr).get();
+        auto c_tls = tls::wrap_client(creds, std::move(c), sstring{},
+                                      tls::tls_options{.wait_for_eof_on_shutdown = false}).get();
+        auto s = sa.get();
+
+        auto in = s.connection.input();
+        auto out = c_tls.output();
+
+        // Write some data in the socket to handshake.
+        out.write("apa").get();
+        auto f = out.flush();
+        auto buf = in.read().get0();
+        f.get();
+        BOOST_CHECK(sstring(buf.begin(), buf.end()) == "apa");
+
+        // Prevent the server from reading from the connection.
+        // This ensures that it will miss the bye message and not
+        // reply with an eof.
+        server.abort_accept();
+
+        // Initiate closing of the TLS session
+        c_tls.shutdown_input();
+        c_tls.shutdown_output();
+
+        // Ensure that the session is closed promptly. When wait_for_eof_on_shutdown is not
+        // specified, the call to wait_input_shutdown will hang for 10 seconds waiting for
+        // and eof from the server.
+        try {
+            with_timeout(std::chrono::steady_clock::now() + 1s, c_tls.wait_input_shutdown()).get();
+        } catch (timed_out_error&) {
+            BOOST_FAIL("Timed out while waiting for input shutdown."
+                       "This indicates the EOF wait was not skipped");
+        }
+    }
+}
+

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -67,7 +67,7 @@ using namespace seastar;
 
 static future<> connect_to_ssl_addr(::shared_ptr<tls::certificate_credentials> certs, socket_address addr, const sstring& name = {}) {
     return repeat_until_value([=]() mutable {
-        return tls::connect(certs, addr, name).then([](connected_socket s) {
+        return tls::connect(certs, addr, tls::tls_options{.server_name = name}).then([](connected_socket s) {
             return do_with(std::move(s), [](connected_socket& s) {
                 return do_with(s.output(), [&s](auto& os) {
                     static const sstring msg("GET / HTTP/1.0\r\n\r\n");
@@ -592,7 +592,7 @@ static future<> run_echo_test(sstring message,
             }
             return server->invoke_on_all(&echoserver::listen, addr, crt, key, ca, server_trust);
         }).then([=] {
-            return tls::connect(certs, addr, name).then([loops, msg, do_read](::connected_socket s) {
+            return tls::connect(certs, addr, tls::tls_options{.server_name=name}).then([loops, msg, do_read](::connected_socket s) {
                 auto strms = ::make_lw_shared<streams>(std::move(s));
                 auto range = boost::irange(0, loops);
                 return do_for_each(range, [strms, msg](auto) {
@@ -1455,7 +1455,7 @@ SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
         // Initiate a connection while specifying that it should not wait for eof on shutdown.
         auto sa = server.accept();
         auto c = engine().connect(addr).get();
-        auto c_tls = tls::wrap_client(creds, std::move(c), sstring{},
+        auto c_tls = tls::wrap_client(creds, std::move(c),
                                       tls::tls_options{.wait_for_eof_on_shutdown = false}).get();
         auto s = sa.get();
 


### PR DESCRIPTION
We merged https://github.com/redpanda-data/seastar/pull/63 into the v23.2.x before the https://github.com/scylladb/seastar/pull/1797 was merged. Now that upstream has merged, revert the original PR and cherry pick from upstream.

I also had to cherry pick the commits of https://github.com/scylladb/seastar/pull/1629 in order to get the new test from. https://github.com/redpanda-data/seastar/commit/7164ae143e0d0493a1c8bd91b45e9c0c87ab5deb to cherry pick nicely.