### PR TITLE
tls: Add certificate_credentials to reload_callback

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -152,6 +152,10 @@ namespace tls {
      */
     using dn_callback = noncopyable_function<void(session_type type, sstring subject, sstring issuer)>;
 
+    class certificate_credentials;
+    void* get_impl(certificate_credentials const&);
+
+
     /**
      * Holds certificates and keys.
      *
@@ -224,6 +228,7 @@ namespace tls {
         friend class credentials_builder;
         template<typename Base>
         friend class reloadable_credentials;
+        friend void* get_impl(const certificate_credentials &creds);
         shared_ptr<impl> _impl;
     };
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -264,6 +264,7 @@ namespace tls {
     class reloadable_credentials_base;
 
     using reload_callback = std::function<void(const std::unordered_set<sstring>&, std::exception_ptr)>;
+    using reload_callback_with_creds = std::function<void(const std::unordered_set<sstring>&, const certificate_credentials&, std::exception_ptr)>;
 
     /**
      * Intentionally "primitive", and more importantly, copyable
@@ -301,7 +302,9 @@ namespace tls {
         // same as above, but any files used for certs/keys etc will be watched
         // for modification and reloaded if changed
         future<shared_ptr<certificate_credentials>> build_reloadable_certificate_credentials(reload_callback = {}, std::optional<std::chrono::milliseconds> tolerance = {}) const;
+        future<shared_ptr<certificate_credentials>> build_reloadable_certificate_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
         future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback = {}, std::optional<std::chrono::milliseconds> tolerance = {}) const;
+        future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
     private:
         friend class reloadable_credentials_base;
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -423,6 +423,7 @@ public:
 private:
     friend class credentials_builder;
     friend class session;
+    friend void* get_impl(certificate_credentials const&);
 
     bool need_load_system_trust() const {
         return _load_system_trust;
@@ -1961,6 +1962,9 @@ std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name& a) {
     return os << a.type << "=" << a.value;
 }
 
+void* tls::get_impl(const tls::certificate_credentials &creds) {
+    return creds._impl->_creds;
+}
 
 }
 

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -964,6 +964,57 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates) {
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_creds) {
+    tmpdir tmp;
+
+    namespace fs = std::filesystem;
+
+    // copy the wrong certs. We don't trust these
+    // blocking calls, but this is a test and seastar does not have a copy
+    // util and I am lazy...
+    fs::copy_file(certfile("other.crt"), tmp.path() / "test.crt");
+    fs::copy_file(certfile("other.key"), tmp.path() / "test.key");
+
+    auto cert = (tmp.path() / "test.crt").native();
+    auto key = (tmp.path() / "test.key").native();
+    std::unordered_set<sstring> changed;
+    promise<> p;
+
+    tls::credentials_builder b;
+    b.set_x509_key_file(cert, key, tls::x509_crt_format::PEM).get();
+    b.set_dh_level();
+
+    auto certs = b.build_reloadable_server_credentials([&](const std::unordered_set<sstring>& files,
+                                                           const tls::certificate_credentials &creds,
+                                                           std::exception_ptr ep) {
+        if (ep) {
+            return;
+        }
+        changed.insert(files.begin(), files.end());
+        if (changed.count(cert) && changed.count(key)) {
+            p.set_value();
+        }
+
+        BOOST_CHECK(get_impl(creds) != nullptr);
+
+    }).get0();
+
+    BOOST_CHECK(certs != nullptr && get_impl(*certs) != nullptr);
+
+    // copy the right (trusted) certs over the old ones.
+    fs::copy_file(certfile("test.crt"), tmp.path() / "test0.crt");
+    fs::copy_file(certfile("test.key"), tmp.path() / "test0.key");
+
+    rename_file((tmp.path() / "test0.crt").native(), (tmp.path() / "test.crt").native()).get();
+    rename_file((tmp.path() / "test0.key").native(), (tmp.path() / "test.key").native()).get();
+
+    p.get_future().get();
+
+    // confirm that we did indeed reload some credentials
+    BOOST_CHECK(!changed.empty());
+
+}
+
 SEASTAR_THREAD_TEST_CASE(test_reload_broken_certificates) {
     tmpdir tmp;
 


### PR DESCRIPTION
Required for https://github.com/redpanda-data/redpanda/pull/13477
Referenced by https://github.com/oleiman/vtools/tree/seastar-bump-tls_certs