### PR TITLE
httpd: Added server and client addresses to request structure

### DIFF
--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -295,6 +295,12 @@ public:
         throw_system_error_on(r == -1, "getsockname");
         return addr;
     }
+    socket_address get_remote_address() {
+        socket_address addr;
+        auto r = ::getpeername(_fd, &addr.u.sa, &addr.addr_length);
+        throw_system_error_on(r == -1, "getpeername");
+        return addr;
+    }
     void listen(int backlog) {
         auto fd = ::listen(_fd, backlog);
         throw_system_error_on(fd == -1, "listen");

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -37,6 +37,7 @@
 #include <strings.h>
 #include <seastar/http/common.hh>
 #include <seastar/http/mime_types.hh>
+#include <seastar/net/socket_defs.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/string_utils.hh>
 
@@ -55,6 +56,8 @@ struct request {
             other, multipart, app_x_www_urlencoded,
     };
 
+    socket_address _client_address;
+    socket_address _server_address;
     sstring _method;
     sstring _url;
     sstring _version;
@@ -75,6 +78,22 @@ struct request {
     sstring protocol_name = "http";
     noncopyable_function<future<>(output_stream<char>&&)> body_writer; // for client
     int listener_idx;
+
+    /**
+     * Get the address of the client that generated the request
+     * @return The address of the client that generated the request
+     */
+    const socket_address & get_client_address() const {
+        return _client_address;
+    }
+
+    /**
+     * Get the address of the server that handled the request
+     * @return The address of the server that handled the request
+     */
+    const socket_address & get_server_address() const {
+        return _server_address;
+    }
 
     /**
      * Search for the first header of a given name

--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -224,6 +224,8 @@ public:
     int get_sockopt(int level, int optname, void* data, size_t len) const;
     /// Local address of the socket
     socket_address local_address() const noexcept;
+    /// Remote address of the socket
+    socket_address remote_address() const noexcept;
 
     /// Disables output to the socket.
     ///

--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -47,6 +47,7 @@ public:
     virtual void set_sockopt(int level, int optname, const void* data, size_t len) = 0;
     virtual int get_sockopt(int level, int optname, void* data, size_t len) const = 0;
     virtual socket_address local_address() const noexcept = 0;
+    virtual socket_address remote_address() const noexcept = 0;
     virtual future<> wait_input_shutdown() = 0;
 };
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -224,6 +224,9 @@ future<> connection::read_one() {
         ++_server._requests_served;
         std::unique_ptr<http::request> req = _parser.get_parsed_request();
         req->listener_idx = _listener_idx;
+        req->_server_address = _fd.local_address();
+        req->_client_address = _fd.remote_address();
+
         if (_tls) {
             req->protocol_name = "https";
         }

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -107,6 +107,7 @@ public:
     int get_sockopt(int level, int optname, void* data, size_t len) const override;
     void set_sockopt(int level, int optname, const void* data, size_t len) override;
     socket_address local_address() const noexcept override;
+    socket_address remote_address() const noexcept override;
     virtual future<> wait_input_shutdown() override;
 };
 
@@ -272,6 +273,11 @@ int native_connected_socket_impl<Protocol>::get_sockopt(int level, int optname, 
 template<typename Protocol>
 socket_address native_connected_socket_impl<Protocol>::local_address() const noexcept {
     return {_conn->local_ip(), _conn->local_port()};
+}
+
+template<typename Protocol>
+socket_address native_connected_socket_impl<Protocol>::remote_address() const noexcept {
+    return {_conn->foreign_ip(), _conn->foreign_port()};
 }
 
 template <typename Protocol>

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -107,6 +107,9 @@ public:
     virtual socket_address local_address(file_desc& _fd) const {
         return _fd.get_address();
     }
+    virtual socket_address remote_address(file_desc& _fd) const {
+        return _fd.get_remote_address();
+    }
 };
 
 thread_local posix_ap_server_socket_impl::sockets_map_t posix_ap_server_socket_impl::sockets{};
@@ -280,6 +283,9 @@ public:
     }
     socket_address local_address() const noexcept override {
         return _ops->local_address(_fd.get_file_desc());
+    }
+    socket_address remote_address() const noexcept override {
+        return _ops->remote_address(_fd.get_file_desc());
     }
     future<> wait_input_shutdown() override {
         return _fd.poll_rdhup();

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -150,6 +150,10 @@ socket_address connected_socket::local_address() const noexcept {
     return _csi->local_address();
 }
 
+socket_address connected_socket::remote_address() const noexcept {
+    return _csi->remote_address();
+}
+
 void connected_socket::shutdown_output() {
     _csi->shutdown_output();
 }

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1772,6 +1772,9 @@ public:
     socket_address local_address() const noexcept override {
         return _session->socket().local_address();
     }
+    socket_address remote_address() const noexcept override {
+        return _session->socket().remote_address();
+    }
     future<std::optional<session_dn>> get_distinguished_name() {
         return _session->get_distinguished_name();
     }

--- a/tests/unit/loopback_socket.hh
+++ b/tests/unit/loopback_socket.hh
@@ -204,6 +204,10 @@ public:
         // dummy
         return {};
     }
+    socket_address remote_address() const noexcept override {
+        // dummy
+        return {};
+    }
     future<> wait_input_shutdown() override {
         return _rx->wait_input_shutdown();
     }


### PR DESCRIPTION
There is a need to know where an HTTP request originated from and what local address it arrived on.  This PR addresses this by adding `client_address` and `server_address` fields to the `http::request` structure.  This also adds in the infrastructure necessary to get the client address from the underlying connection.