### PR TITLE
Expose TLS certificate details

### DIFF
--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -169,6 +169,12 @@ struct session_dn {
     sstring issuer;
 };
 
+  /// Information about a certificate
+struct cert_info {
+    sstring serial;
+    time_t expiry;
+};
+
 /// A TCP (or other stream-based protocol) connection.
 ///
 /// A \c connected_socket represents a full-duplex stream between

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -259,6 +259,7 @@ namespace tls {
     class reloadable_credentials_base;
 
     using reload_callback = std::function<void(const std::unordered_set<sstring>&, std::exception_ptr)>;
+    using reload_callback_with_creds = std::function<void(const std::unordered_set<sstring>&, const certificate_credentials&, std::exception_ptr)>;
 
     /**
      * Intentionally "primitive", and more importantly, copyable
@@ -296,7 +297,9 @@ namespace tls {
         // same as above, but any files used for certs/keys etc will be watched
         // for modification and reloaded if changed
         future<shared_ptr<certificate_credentials>> build_reloadable_certificate_credentials(reload_callback = {}, std::optional<std::chrono::milliseconds> tolerance = {}) const;
+        future<shared_ptr<certificate_credentials>> build_reloadable_certificate_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
         future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback = {}, std::optional<std::chrono::milliseconds> tolerance = {}) const;
+        future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
     private:
         friend class reloadable_credentials_base;
 

--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -216,6 +216,24 @@ namespace tls {
          */
         void set_dn_verification_callback(dn_callback);
 
+        /**
+         * Retrieve information about loaded certificates.
+         *
+         * Returns a std::vector of cert_info, each extracted from a loaded
+         * certificate, std::nullopt if the impl does not exist or we detect
+         * an error during extraction.
+         */
+        std::optional<std::vector<cert_info>> get_cert_info() const noexcept;
+
+        /**
+         * Retrieve information about the loaded current trust list.
+         *
+         * Returns a std::vector of cert_info, each extracted from a CA in the
+         * trust list, std::nullopt if the impl does not exist or we detect
+         * an error during extraction.
+         */
+        std::optional<std::vector<cert_info>> get_trust_list_info() const noexcept;
+
     private:
         class impl;
         friend class session;

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -39,6 +39,7 @@ module;
 #include <boost/range/adaptor/map.hpp>
 
 #include <fmt/core.h>
+#include <seastar/util/defer.hh>
 
 #ifdef SEASTAR_MODULE
 module seastar;
@@ -170,6 +171,15 @@ static void gtls_chk(int res) {
     if (res < 0) {
         throw std::system_error(res, tls::error_category());
     }
+}
+
+static sstring extract_x509_serial(gnutls_x509_crt_t cert) {
+    constexpr size_t serial_max = 128;
+    size_t serial_size{serial_max};
+    sstring serial(sstring::initialized_later{}, serial_size);
+    gtls_chk(gnutls_x509_crt_get_serial(cert, serial.data(), &serial_size));
+    serial.resize(serial_size);
+    return serial;
 }
 
 namespace {
@@ -387,6 +397,49 @@ public:
                 gnutls_certificate_set_x509_simple_pkcs12_mem(_creds, &w,
                         gnutls_x509_crt_fmt_t(fmt), password.c_str()));
     }
+    std::vector<cert_info> get_x509_info() const {
+        gnutls_x509_crt_t *crt_list{};
+        unsigned int crt_list_size{};
+        gtls_chk(gnutls_certificate_get_x509_crt(*this, 0, &crt_list, &crt_list_size));
+        auto cleanup = defer([&crt_list, crt_list_size]() noexcept {
+            for (unsigned int i = 0; i < crt_list_size; ++i) {
+                gnutls_x509_crt_deinit(crt_list[i]);
+            }
+            gnutls_free(crt_list);
+        });
+
+        std::vector<cert_info> result;
+        result.reserve(crt_list_size);
+
+        for (unsigned int i = 0; i < crt_list_size; ++i) {
+            cert_info info = {
+                .serial = extract_x509_serial(crt_list[i]),
+                .expiry = gnutls_x509_crt_get_expiration_time(crt_list[i]),
+            };
+            result.emplace_back(std::move(info));
+        }
+        return result;
+    }
+    std::vector<cert_info> get_x509_trust_list_info() const {
+        gnutls_x509_trust_list_t tlist{};
+        gnutls_certificate_get_trust_list(*this, &tlist);
+        gnutls_x509_trust_list_iter_t iter{};
+        gnutls_x509_crt_t cert{};
+
+        // Size not known up front
+        std::vector<cert_info> result;
+        while (GNUTLS_E_REQUESTED_DATA_NOT_AVAILABLE !=
+               gnutls_x509_trust_list_iter_get_ca(tlist, &iter, &cert)) {
+            cert_info info = {
+                .serial = extract_x509_serial(cert),
+                .expiry = gnutls_x509_crt_get_expiration_time(cert),
+            };
+            result.emplace_back(std::move(info));
+            gnutls_x509_crt_deinit(cert);
+        }
+
+        return result;
+    }
     void dh_params(const tls::dh_params& dh) {
 #if GNUTLS_VERSION_NUMBER >= 0x030506
         auto sec_param = dh._impl->sec_param();
@@ -526,6 +579,32 @@ void tls::certificate_credentials::set_priority_string(const sstring& prio) {
 
 void tls::certificate_credentials::set_dn_verification_callback(dn_callback cb) {
     _impl->set_dn_verification_callback(std::move(cb));
+}
+
+std::optional<std::vector<cert_info>> tls::certificate_credentials::get_cert_info() const noexcept {
+    if (_impl == nullptr) {
+        return std::nullopt;
+    }
+
+    try {
+        auto result = _impl->get_x509_info();
+        return result;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<std::vector<cert_info>> tls::certificate_credentials::get_trust_list_info() const noexcept {
+    if (_impl == nullptr) {
+        return std::nullopt;
+    }
+
+    try {
+        auto result = _impl->get_x509_trust_list_info();
+        return result;
+    } catch (...) {
+        return std::nullopt;
+    }
 }
 
 tls::server_credentials::server_credentials()
@@ -976,7 +1055,7 @@ void tls::reloadable_credentials<tls::certificate_credentials>::rebuild(const cr
 }
 
 template <>
-const tls::certificate_credentials &tls::reloadable_credentials<tls::certificate_credentials>::as_certificate_credentials() const noexcept {
+const tls::certificate_credentials& tls::reloadable_credentials<tls::certificate_credentials>::as_certificate_credentials() const noexcept {
     return *this;
 }
 
@@ -987,7 +1066,7 @@ void tls::reloadable_credentials<tls::server_credentials>::rebuild(const credent
 }
 
 template <>
-const tls::certificate_credentials &tls::reloadable_credentials<tls::server_credentials>::as_certificate_credentials() const noexcept{
+const tls::certificate_credentials& tls::reloadable_credentials<tls::server_credentials>::as_certificate_credentials() const noexcept{
     return *this;
 }
 
@@ -1994,7 +2073,6 @@ std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name::value_ty
 std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name& a) {
     return os << a.type << "=" << a.value;
 }
-
 
 }
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -195,6 +195,14 @@ static auto get_gtls_string = [](auto func, auto... args) noexcept {
     return std::make_pair(ret, res);
 };
 
+tls::reload_callback_with_creds wrap_reload_callback(tls::reload_callback cb) {
+    return [cb{std::move(cb)}](const std::unordered_set<sstring> &files,
+                               const tls::certificate_credentials&,
+                               std::exception_ptr ep) {
+        return cb(files, ep);
+    };
+}
+
 }
 
 class tls::dh_params::impl : gnutlsobj {
@@ -729,7 +737,7 @@ public:
     public:
         using time_point = std::chrono::system_clock::time_point;
 
-        reloading_builder(credentials_builder b, reload_callback cb, reloadable_credentials_base* creds, delay_type delay)
+        reloading_builder(credentials_builder b, reload_callback_with_creds cb, reloadable_credentials_base* creds, delay_type delay)
             : credentials_builder(std::move(b))
             , _cb(std::move(cb))
             , _creds(creds)
@@ -785,6 +793,7 @@ public:
             _fsn.shutdown();
             _timer.cancel();
         }
+
     private:
         using fsnotifier = experimental::fsnotifier;
 
@@ -887,8 +896,9 @@ public:
             }
         }
         void do_callback(std::exception_ptr ep = {}) {
-            if (_cb && !_files.empty()) {
-                _cb(boost::copy_range<std::unordered_set<sstring>>(_files | boost::adaptors::map_keys), std::move(ep));
+            if (_cb && !_files.empty() && _creds) {
+                const auto &creds = _creds->as_certificate_credentials();
+                _cb(boost::copy_range<std::unordered_set<sstring>>(_files | boost::adaptors::map_keys), creds, std::move(ep));
             }
         }
         // called from seastar::thread
@@ -921,7 +931,7 @@ public:
             });
         }
 
-        reload_callback _cb;
+        reload_callback_with_creds _cb;
         reloadable_credentials_base* _creds;
         fsnotifier _fsn;
         std::unordered_map<fsnotifier::watch_token, std::pair<fsnotifier::watch, sstring>> _watches;
@@ -930,7 +940,7 @@ public:
         timer<> _timer;
         delay_type _delay;
     };
-    reloadable_credentials_base(credentials_builder builder, reload_callback cb, delay_type delay = default_tolerance)
+    reloadable_credentials_base(credentials_builder builder, reload_callback_with_creds cb, delay_type delay = default_tolerance)
         : _builder(seastar::make_shared<reloading_builder>(std::move(builder), std::move(cb), this, delay))
     {
         _builder->start();
@@ -942,6 +952,7 @@ public:
         _builder->detach();
     }
     virtual void rebuild(const credentials_builder&) = 0;
+    virtual const tls::certificate_credentials& as_certificate_credentials() const noexcept = 0;
 private:
     shared_ptr<reloading_builder> _builder;
 };
@@ -949,11 +960,13 @@ private:
 template<typename Base>
 class tls::reloadable_credentials : public Base, public tls::reloadable_credentials_base {
 public:
-    reloadable_credentials(credentials_builder builder, reload_callback cb, Base b, delay_type delay = default_tolerance)
+    reloadable_credentials(credentials_builder builder, reload_callback_with_creds cb, Base b, delay_type delay = default_tolerance)
         : Base(std::move(b))
         , tls::reloadable_credentials_base(std::move(builder), std::move(cb), delay)
     {}
     void rebuild(const credentials_builder&) override;
+    const tls::certificate_credentials& as_certificate_credentials() const noexcept override;
+
 };
 
 template<>
@@ -962,13 +975,27 @@ void tls::reloadable_credentials<tls::certificate_credentials>::rebuild(const cr
     this->_impl = std::move(tmp->_impl);
 }
 
+template <>
+const tls::certificate_credentials &tls::reloadable_credentials<tls::certificate_credentials>::as_certificate_credentials() const noexcept {
+    return *this;
+}
+
 template<>
 void tls::reloadable_credentials<tls::server_credentials>::rebuild(const credentials_builder& builder) {
     auto tmp = builder.build_server_credentials();
     this->_impl = std::move(tmp->_impl);
 }
 
+template <>
+const tls::certificate_credentials &tls::reloadable_credentials<tls::server_credentials>::as_certificate_credentials() const noexcept{
+    return *this;
+}
+
 future<shared_ptr<tls::certificate_credentials>> tls::credentials_builder::build_reloadable_certificate_credentials(reload_callback cb, std::optional<std::chrono::milliseconds> tolerance) const {
+    return build_reloadable_certificate_credentials(wrap_reload_callback(std::move(cb)), tolerance);
+}
+
+future<shared_ptr<tls::certificate_credentials>> tls::credentials_builder::build_reloadable_certificate_credentials(reload_callback_with_creds cb, std::optional<std::chrono::milliseconds> tolerance) const {
     auto creds = seastar::make_shared<reloadable_credentials<tls::certificate_credentials>>(*this, std::move(cb), std::move(*build_certificate_credentials()), tolerance.value_or(reloadable_credentials_base::default_tolerance));
     return creds->init().then([creds] {
         return make_ready_future<shared_ptr<tls::certificate_credentials>>(creds);
@@ -976,6 +1003,10 @@ future<shared_ptr<tls::certificate_credentials>> tls::credentials_builder::build
 }
 
 future<shared_ptr<tls::server_credentials>> tls::credentials_builder::build_reloadable_server_credentials(reload_callback cb, std::optional<std::chrono::milliseconds> tolerance) const {
+    return build_reloadable_server_credentials(wrap_reload_callback(std::move(cb)), tolerance);
+}
+
+future<shared_ptr<tls::server_credentials>> tls::credentials_builder::build_reloadable_server_credentials(reload_callback_with_creds cb, std::optional<std::chrono::milliseconds> tolerance) const {
     auto creds = seastar::make_shared<reloadable_credentials<tls::server_credentials>>(*this, std::move(cb), std::move(*build_server_credentials()), tolerance.value_or(reloadable_credentials_base::default_tolerance));
     return creds->init().then([creds] {
         return make_ready_future<shared_ptr<tls::server_credentials>>(creds);

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -964,6 +964,68 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates) {
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_creds) {
+    tmpdir tmp;
+
+    namespace fs = std::filesystem;
+
+    // copy the wrong certs. We don't trust these
+    // blocking calls, but this is a test and seastar does not have a copy
+    // util and I am lazy...
+    fs::copy_file(certfile("other.crt"), tmp.path() / "test.crt");
+    fs::copy_file(certfile("other.key"), tmp.path() / "test.key");
+
+    auto cert = (tmp.path() / "test.crt").native();
+    auto key = (tmp.path() / "test.key").native();
+    std::unordered_set<sstring> changed;
+    promise<> p;
+
+    tls::credentials_builder b;
+    b.set_x509_key_file(cert, key, tls::x509_crt_format::PEM).get();
+    b.set_dh_level();
+
+    auto certs = b.build_reloadable_server_credentials([&](const std::unordered_set<sstring> &files,
+                                                           const tls::certificate_credentials &creds,
+                                                           std::exception_ptr ep) {
+        if (ep) {
+            return;
+        }
+
+        changed.insert(files.begin(), files.end());
+        if (changed.count(cert) && changed.count(key)) {
+            p.set_value();
+        }
+
+        auto certs_info = creds.get_cert_info();
+        auto trust_list_info = creds.get_trust_list_info();
+
+        BOOST_CHECK(certs_info.has_value() && !certs_info.value().empty());
+        BOOST_CHECK(trust_list_info.has_value() && trust_list_info.value().empty());
+
+    }).get0();
+
+    BOOST_CHECK(certs != nullptr);
+
+    auto certs_info = certs->get_cert_info();
+    auto trust_list_info = certs->get_trust_list_info();
+
+    BOOST_CHECK(certs_info.has_value() && !certs_info.value().empty());
+    BOOST_CHECK(trust_list_info.has_value());
+
+    // copy the right (trusted) certs over the old ones.
+    fs::copy_file(certfile("test.crt"), tmp.path() / "test0.crt");
+    fs::copy_file(certfile("test.key"), tmp.path() / "test0.key");
+
+    rename_file((tmp.path() / "test0.crt").native(), (tmp.path() / "test.crt").native()).get();
+    rename_file((tmp.path() / "test0.key").native(), (tmp.path() / "test.key").native()).get();
+
+    p.get_future().get();
+
+    // confirm that we did indeed reload some credentials
+    BOOST_CHECK(!changed.empty());
+
+}
+
 SEASTAR_THREAD_TEST_CASE(test_reload_broken_certificates) {
     tmpdir tmp;
 


### PR DESCRIPTION
This PR introduces an alternative reload callback for reloadable certificate credentials to provide the current `net::tls::certificate_credentials` to the callback receiver.

Also introduces a couple of accessors for same to expose access to serial numbers and expiration times for loaded certs and CAs.

Corresponds to https://github.com/scylladb/seastar/pull/1854