### PR TITLE
Revert "Merge pull request #75 from oleiman/tls_cert_creds"

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -152,10 +152,6 @@ namespace tls {
      */
     using dn_callback = noncopyable_function<void(session_type type, sstring subject, sstring issuer)>;
 
-    class certificate_credentials;
-    void* get_impl(certificate_credentials const&);
-
-
     /**
      * Holds certificates and keys.
      *
@@ -228,7 +224,6 @@ namespace tls {
         friend class credentials_builder;
         template<typename Base>
         friend class reloadable_credentials;
-        friend void* get_impl(const certificate_credentials &creds);
         shared_ptr<impl> _impl;
     };
 
@@ -264,7 +259,6 @@ namespace tls {
     class reloadable_credentials_base;
 
     using reload_callback = std::function<void(const std::unordered_set<sstring>&, std::exception_ptr)>;
-    using reload_callback_with_creds = std::function<void(const std::unordered_set<sstring>&, const certificate_credentials&, std::exception_ptr)>;
 
     /**
      * Intentionally "primitive", and more importantly, copyable
@@ -302,9 +296,7 @@ namespace tls {
         // same as above, but any files used for certs/keys etc will be watched
         // for modification and reloaded if changed
         future<shared_ptr<certificate_credentials>> build_reloadable_certificate_credentials(reload_callback = {}, std::optional<std::chrono::milliseconds> tolerance = {}) const;
-        future<shared_ptr<certificate_credentials>> build_reloadable_certificate_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
         future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback = {}, std::optional<std::chrono::milliseconds> tolerance = {}) const;
-        future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
     private:
         friend class reloadable_credentials_base;
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -195,14 +195,6 @@ static auto get_gtls_string = [](auto func, auto... args) noexcept {
     return std::make_pair(ret, res);
 };
 
-tls::reload_callback_with_creds wrap_reload_callback(tls::reload_callback cb) {
- return [cb{std::move(cb)}](const std::unordered_set<sstring>& files, const tls::certificate_credentials&, std::exception_ptr ep){
-        if(!files.empty()) {
-            return cb(files, ep);
-        }
-    };
-}
-
 }
 
 class tls::dh_params::impl : gnutlsobj {
@@ -431,7 +423,6 @@ public:
 private:
     friend class credentials_builder;
     friend class session;
-    friend void* get_impl(certificate_credentials const&);
 
     bool need_load_system_trust() const {
         return _load_system_trust;
@@ -738,7 +729,7 @@ public:
     public:
         using time_point = std::chrono::system_clock::time_point;
 
-        reloading_builder(credentials_builder b, reload_callback_with_creds cb, reloadable_credentials_base* creds, delay_type delay)
+        reloading_builder(credentials_builder b, reload_callback cb, reloadable_credentials_base* creds, delay_type delay)
             : credentials_builder(std::move(b))
             , _cb(std::move(cb))
             , _creds(creds)
@@ -896,9 +887,8 @@ public:
             }
         }
         void do_callback(std::exception_ptr ep = {}) {
-            if (_cb) {
-                auto creds = _creds->_builder->build_certificate_credentials();
-                _cb(boost::copy_range<std::unordered_set<sstring>>(_files | boost::adaptors::map_keys), *creds, std::move(ep));
+            if (_cb && !_files.empty()) {
+                _cb(boost::copy_range<std::unordered_set<sstring>>(_files | boost::adaptors::map_keys), std::move(ep));
             }
         }
         // called from seastar::thread
@@ -931,7 +921,7 @@ public:
             });
         }
 
-        reload_callback_with_creds _cb;
+        reload_callback _cb;
         reloadable_credentials_base* _creds;
         fsnotifier _fsn;
         std::unordered_map<fsnotifier::watch_token, std::pair<fsnotifier::watch, sstring>> _watches;
@@ -940,7 +930,7 @@ public:
         timer<> _timer;
         delay_type _delay;
     };
-    reloadable_credentials_base(credentials_builder builder, reload_callback_with_creds cb, delay_type delay = default_tolerance)
+    reloadable_credentials_base(credentials_builder builder, reload_callback cb, delay_type delay = default_tolerance)
         : _builder(seastar::make_shared<reloading_builder>(std::move(builder), std::move(cb), this, delay))
     {
         _builder->start();
@@ -959,7 +949,7 @@ private:
 template<typename Base>
 class tls::reloadable_credentials : public Base, public tls::reloadable_credentials_base {
 public:
-    reloadable_credentials(credentials_builder builder, reload_callback_with_creds cb, Base b, delay_type delay = default_tolerance)
+    reloadable_credentials(credentials_builder builder, reload_callback cb, Base b, delay_type delay = default_tolerance)
         : Base(std::move(b))
         , tls::reloadable_credentials_base(std::move(builder), std::move(cb), delay)
     {}
@@ -979,10 +969,6 @@ void tls::reloadable_credentials<tls::server_credentials>::rebuild(const credent
 }
 
 future<shared_ptr<tls::certificate_credentials>> tls::credentials_builder::build_reloadable_certificate_credentials(reload_callback cb, std::optional<std::chrono::milliseconds> tolerance) const {
-    return build_reloadable_certificate_credentials(wrap_reload_callback(std::move(cb)), tolerance);
-}
-
-future<shared_ptr<tls::certificate_credentials>> tls::credentials_builder::build_reloadable_certificate_credentials(reload_callback_with_creds cb, std::optional<std::chrono::milliseconds> tolerance) const {
     auto creds = seastar::make_shared<reloadable_credentials<tls::certificate_credentials>>(*this, std::move(cb), std::move(*build_certificate_credentials()), tolerance.value_or(reloadable_credentials_base::default_tolerance));
     return creds->init().then([creds] {
         return make_ready_future<shared_ptr<tls::certificate_credentials>>(creds);
@@ -990,10 +976,6 @@ future<shared_ptr<tls::certificate_credentials>> tls::credentials_builder::build
 }
 
 future<shared_ptr<tls::server_credentials>> tls::credentials_builder::build_reloadable_server_credentials(reload_callback cb, std::optional<std::chrono::milliseconds> tolerance) const {
-    return build_reloadable_server_credentials(wrap_reload_callback(std::move(cb)), tolerance);
-}
-
-future<shared_ptr<tls::server_credentials>> tls::credentials_builder::build_reloadable_server_credentials(reload_callback_with_creds cb, std::optional<std::chrono::milliseconds> tolerance) const {
     auto creds = seastar::make_shared<reloadable_credentials<tls::server_credentials>>(*this, std::move(cb), std::move(*build_server_credentials()), tolerance.value_or(reloadable_credentials_base::default_tolerance));
     return creds->init().then([creds] {
         return make_ready_future<shared_ptr<tls::server_credentials>>(creds);
@@ -1982,9 +1964,6 @@ std::ostream& tls::operator<<(std::ostream& os, const subject_alt_name& a) {
     return os << a.type << "=" << a.value;
 }
 
-void* tls::get_impl(const tls::certificate_credentials &creds) {
-    return creds._impl->_creds;
-}
 
 }
 


### PR DESCRIPTION
This reverts commit ab57ab6fe980420054bf94dd54d86c36f70c5d18, reversing changes made to c83e0172983753c61fa7361262e5f12a91eeacea.

This change broke one of the TLS unit tests (tls_test.cc::test_reload_broken_certificates) - an unhandled exception diverted control from the reload callback, causing a continuation in the test to block indefinitely.