### PR TITLE
More io-queue metrics

### DIFF
--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -256,6 +256,7 @@ public:
 
     capacity_t capacity_deficiency(capacity_t from) const noexcept;
     capacity_t ticket_capacity(fair_queue_ticket ticket) const noexcept;
+    capacity_t max_extra() const noexcept;
 
     std::chrono::duration<double> rate_limit_duration() const noexcept {
         std::chrono::duration<double, rate_resolution> dur((double)_token_bucket.limit() / _token_bucket.rate());
@@ -328,9 +329,12 @@ private:
     capacity_t _last_accumulated = 0;
     // Metric to count how many times dispatch has been throttled on the per tick threshold
     size_t _throttled_per_tick_threshold = 0;
-    // Metric to count the number of times this class was throttled dispatching
-    // because the token bucket run out of capacity
-    size_t _throttled_no_capacity = 0;
+    // Metrics to count the number of times this class was throttled dispatching
+    // because of the token bucket
+    // Throttled because of rate based limiting in the token bucket
+    size_t _throttled_no_capacity_rate = 0;
+    // Throttled because of disk feedback based limiting in the token bucket
+    size_t _throttled_no_capacity_feedback = 0;
 
     /*
      * When the shared capacity os over the local queue delays

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -326,6 +326,8 @@ private:
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     size_t _nr_classes = 0;
     capacity_t _last_accumulated = 0;
+    // Metric to count how many times dispatch has been throttled on the per tick threshold
+    size_t _throttled_per_tick_threshold = 0;
 
     /*
      * When the shared capacity os over the local queue delays
@@ -404,6 +406,8 @@ public:
     clock_type::time_point next_pending_aio() const noexcept;
 
     std::vector<seastar::metrics::impl::metric_definition_impl> metrics(class_id c);
+    // Metrics that are accounted across all classes
+    std::vector<seastar::metrics::impl::metric_definition_impl> global_metrics();
 };
 /// @}
 

--- a/include/seastar/core/fair_queue.hh
+++ b/include/seastar/core/fair_queue.hh
@@ -328,6 +328,9 @@ private:
     capacity_t _last_accumulated = 0;
     // Metric to count how many times dispatch has been throttled on the per tick threshold
     size_t _throttled_per_tick_threshold = 0;
+    // Metric to count the number of times this class was throttled dispatching
+    // because the token bucket run out of capacity
+    size_t _throttled_no_capacity = 0;
 
     /*
      * When the shared capacity os over the local queue delays

--- a/include/seastar/core/internal/io_sink.hh
+++ b/include/seastar/core/internal/io_sink.hh
@@ -73,6 +73,10 @@ public:
         _pending_io.erase(_pending_io.begin(), _pending_io.begin() + drained);
         return drained;
     }
+
+    size_t queue_length() const {
+        return _pending_io.size();
+    }
 };
 
 } // namespace internal

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -96,6 +96,7 @@ private:
     io_group_ptr _group;
     boost::container::small_vector<fair_queue, 2> _streams;
     internal::io_sink& _sink;
+    seastar::metrics::metric_groups _metrics;
 
     friend struct ::io_queue_for_tests;
     priority_class_data& find_or_create_class(internal::priority_class pc);
@@ -195,6 +196,7 @@ public:
 private:
     static fair_queue::config make_fair_queue_config(const config& cfg, sstring label);
     void register_stats(sstring name, priority_class_data& pc);
+    void register_global_stats();
 };
 
 class io_group {

--- a/include/seastar/util/shared_token_bucket.hh
+++ b/include/seastar/util/shared_token_bucket.hh
@@ -189,6 +189,10 @@ public:
         return wrapping_difference(from, head());
     }
 
+    T max_extra() const noexcept {
+        return _rovers.max_extra(_replenish_limit);
+    }
+
     template <typename Rep, typename Per>
     static auto rate_cast(const std::chrono::duration<Rep, Per> delta) noexcept {
         return std::chrono::duration_cast<rate_resolution>(delta);

--- a/src/core/fair_queue.cc
+++ b/src/core/fair_queue.cc
@@ -383,6 +383,7 @@ void fair_queue::dispatch_requests(std::function<void(fair_queue_entry&)> cb) {
         auto& req = h._queue.front();
         auto gr = grab_capacity(req);
         if (gr == grab_result::pending) {
+            _throttled_no_capacity++;
             break;
         }
 
@@ -457,6 +458,9 @@ std::vector<seastar::metrics::impl::metric_definition_impl> fair_queue::global_m
             sm::make_counter("throttled_per_tick_threshold",
                     [this] { return _throttled_per_tick_threshold; },
                     sm::description("Number of times dispatch was throttled on the per tick threshold")),
+            sm::make_counter("throttled_no_capacity",
+                    [this] { return _throttled_no_capacity; },
+                    sm::description("Number of times this class was throttled dispatching requests because of lacking token bucket capacity")),
     });
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2685,6 +2685,8 @@ void reactor::register_metrics() {
             // total_operations value:DERIVE:0:U
             sm::make_counter("io_threaded_fallbacks", std::bind(&thread_pool::operation_count, _thread_pool.get()),
                     sm::description("Total number of io-threaded-fallbacks operations")),
+            sm::make_queue_length("io_sink_queue_length", [this] { return _io_sink.queue_length(); },
+                    sm::description("Number of operations in the io sink queue")),
 
     });
 


### PR DESCRIPTION
Adds metrics for:
 - io-sink queue length
 - io-queue: Number of times dispatch was throttled by per-tick dispatch limit
 - io-queue: Number of times dispatch was throttled by the tokenbucket

Most patches intentionally kept rather simple (also in regards to upstreaming). The last commit (differentiating between disk feedback driven throttling and rate based throttling) could be dropped though I think it's useful.