### PR TITLE
[v23.3.x] loop: Fix iterator_range_estimate_vector_capacity for random iters

### DIFF
--- a/include/seastar/core/loop.hh
+++ b/include/seastar/core/loop.hh
@@ -503,17 +503,14 @@ struct has_iterator_category<T, std::void_t<typename std::iterator_traits<T>::it
 template <typename Iterator, typename Sentinel, typename IteratorCategory>
 inline
 size_t
-iterator_range_estimate_vector_capacity(Iterator const&, Sentinel const&, IteratorCategory) {
+iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end, IteratorCategory) {
+    // May be linear time below random_access_iterator_tag, but still better than reallocation
+    if constexpr (std::is_base_of<std::forward_iterator_tag, IteratorCategory>::value) {
+        return std::distance(begin, end);
+    }
+
     // For InputIterators we can't estimate needed capacity
     return 0;
-}
-
-template <typename Iterator, typename Sentinel>
-inline
-size_t
-iterator_range_estimate_vector_capacity(Iterator begin, Sentinel end, std::forward_iterator_tag) {
-    // May be linear time below random_access_iterator_tag, but still better than reallocation
-    return std::distance(begin, end);
 }
 
 } // namespace internal


### PR DESCRIPTION
The implementation uses tag dispatch to call out to `std::distance` for
forward iterators and below.

However this doesn't work as expected for random iterators. They will
actually get dispatched to the default template version.

Hence, functions that use `iterator_range_estimate_vector_capacity`
don't pre-reserve anything for `std::vector` or similar classes.

This causes lots of reallocations when using `seastar::when_all` or
similar.

Change the implementation to also call out to std::distance for derived
types.

(cherry picked from commit https://github.com/redpanda-data/seastar/commit/22f5b4ed62c9e88f6f63aee7d276cf205558641e)