### PR TITLE
net/tls: Adjust type for cert_info.serial

### DIFF
--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -171,7 +171,9 @@ struct session_dn {
 
   /// Information about a certificate
 struct cert_info {
-    sstring serial;
+    static constexpr size_t bytes_inline_size = 31;
+    using bytes = basic_sstring<uint8_t, uint32_t, bytes_inline_size, false>;
+    bytes serial;
     time_t expiry;
 };
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -173,10 +173,10 @@ static void gtls_chk(int res) {
     }
 }
 
-static sstring extract_x509_serial(gnutls_x509_crt_t cert) {
+static cert_info::bytes extract_x509_serial(gnutls_x509_crt_t cert) {
     constexpr size_t serial_max = 128;
     size_t serial_size{serial_max};
-    sstring serial(sstring::initialized_later{}, serial_size);
+    cert_info::bytes serial(cert_info::bytes::initialized_later{}, serial_size);
     gtls_chk(gnutls_x509_crt_get_serial(cert, serial.data(), &serial_size));
     serial.resize(serial_size);
     return serial;


### PR DESCRIPTION
GnuTLS provides serial numbers not as a legible string of hex digits but as a byte array corresponding to an integer value up to 20 octets wide. The cert_info interface should reflect this.

To that end, this commit updates the type of `cert_info::serial` to an non-null-terminated basic_sstring of uint8_t.