### PR TITLE
Fix "seastar::aio_general_context::flush(): Assertion `clock::now() < retry_until'"

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -320,6 +320,7 @@ bool aio_storage_context::can_sleep() const {
 
 aio_general_context::aio_general_context(size_t nr)
         : iocbs(new iocb*[nr])
+        , begin(iocbs.get())
         , last(iocbs.get())
         , end(iocbs.get() + nr)
 {
@@ -331,12 +332,15 @@ aio_general_context::~aio_general_context() {
 }
 
 void aio_general_context::queue(linux_abi::iocb* iocb) {
-    assert(last < end);
-    *last++ = iocb;
+    if (last < end) {
+        *last++ = iocb;
+    } else {
+        iocbs_backlog.push_back(iocb);
+    }
 }
 
 size_t aio_general_context::flush() {
-    auto begin = iocbs.get();
+    auto original_begin = begin;
     while (begin != last) {
         auto r = io_submit(io_context, last - begin, begin);
         if (__builtin_expect(r <= 0, false)) {
@@ -347,14 +351,31 @@ size_t aio_general_context::flush() {
             if (r < 0 && errno != EAGAIN) {
                 on_fatal_internal_error(seastar_logger, format("aio_general_context::flush: io_submit failed with unexpected system error: {}", errno));
             }
-            // just adjust the queue and return the number of iocbs we were able to submit
-            std::move(begin, last, iocbs.get());
             break;
         }
         begin += r;
     }
-    auto nr = begin - iocbs.get();
-    last -= nr;
+
+    auto nr = begin - original_begin;
+
+    if (nr != 0 && begin == last) {
+        // If we have succesfully committed all iocbs (begin == last) then we
+        // reset the pointers. Further at this point we move iocbs from the
+        // backlog to the main `iocbs` array if there are any.
+        // We only do this once `iocbs` is fully empty to get batching behaviour
+        // and avoid degenarate cases where only one element gets submitted
+        // which would result in excessive shifting of the elements in `iocbs`
+        // array or the backlog.
+        begin = iocbs.get();
+        last = iocbs.get();
+
+        if (!iocbs_backlog.empty()) {
+            auto max_to_copy = std::min(size_t(end - begin), iocbs_backlog.size());
+            last = std::move(iocbs_backlog.begin(), iocbs_backlog.begin() + max_to_copy, begin);
+            iocbs_backlog.erase(iocbs_backlog.begin(), iocbs_backlog.begin() + max_to_copy);
+        }
+    }
+
     return nr;
 }
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -337,26 +337,18 @@ void aio_general_context::queue(linux_abi::iocb* iocb) {
 
 size_t aio_general_context::flush() {
     auto begin = iocbs.get();
-    using clock = std::chrono::steady_clock;
-    constexpr clock::time_point no_time_point = clock::time_point(clock::duration(0));
-    auto retry_until = no_time_point;
     while (begin != last) {
         auto r = io_submit(io_context, last - begin, begin);
-        if (__builtin_expect(r > 0, true)) {
-            begin += r;
-            continue;
+        if (__builtin_expect(r <= 0, false)) {
+            // errno == EAGAIN is expected here, but we don't explicitly assert that.
+            // just adjust the queue and return the number of iocbs we were able to submit
+            std::move(begin, last, iocbs.get());
+            break;
         }
-        // errno == EAGAIN is expected here. We don't explicitly assert that
-        // since the assert below prevents an endless loop for any reason.
-        if (retry_until == no_time_point) {
-            // allow retrying for 1 second
-            retry_until = clock::now() + 1s;
-        } else {
-            assert(clock::now() < retry_until);
-        }
+        begin += r;
     }
-    auto nr = last - iocbs.get();
-    last = iocbs.get();
+    auto nr = begin - iocbs.get();
+    last -= nr;
     return nr;
 }
 

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -55,8 +55,12 @@ struct aio_general_context {
     ~aio_general_context();
     internal::linux_abi::aio_context_t io_context{};
     std::unique_ptr<internal::linux_abi::iocb*[]> iocbs;
+    internal::linux_abi::iocb** begin;
     internal::linux_abi::iocb** last;
     internal::linux_abi::iocb** const end;
+    // in case `iocbs` is full queue here, use std::deque to avoid oversized
+    // allocations
+    std::deque<internal::linux_abi::iocb*> iocbs_backlog;
     void queue(internal::linux_abi::iocb* iocb);
     // submit all queued iocbs and return their count.
     size_t flush();


### PR DESCRIPTION
There is a potential crash in the `seastar::aio_general_context`. For more background see https://github.com/scylladb/seastar/issues/1784

We have now hit this in production so we should cherry pick the suggested fix from https://github.com/scylladb/seastar/pull/1788