### PR TITLE
tls: linearize small packets on send

### DIFF
--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1479,6 +1479,18 @@ public:
                return put(std::move(p));
             });
         }
+
+        // We want to make sure that we call gnutls_record_send with as large
+        // packets as possible. This is because each call to gnutls_record_send
+        // translates to a sendmsg syscall. Further it results in larger TLS
+        // records which makes encryption/decryption faster. Hence to avoid
+        // cases where we would do an extra syscall for something like a 100
+        // bytes header we linearize the packet if it's below the max TLS record
+        // size.
+        if (p.nr_frags() > 1 && p.len() <= 16384) {
+            p.linearize();
+        }
+
         auto i = p.fragments().begin();
         auto e = p.fragments().end();
         return with_semaphore(_out_sem, 1, std::bind(&session::do_put, this, i, e)).finally([p = std::move(p)] {});


### PR DESCRIPTION
In Redpanda we were seeing surprisingly large overhead from running with
TLS enabled.

After some debugging we found that this is partly caused by doing an
excessively larger amount of `sendmsg` syscalls compared to when using
plain TCP.

This is caused by the implementation of `tls::session::put` which loops
over each fragment in the passed `net::packet` and treats it separately.
This will result in a call to `gnutls_record_send` for each fragment in
the packet (and consequently a call to `sendmsg` for each fragment via
the vector push function).

This can cause excessive overhead for `net::packets` which represent a
"packet" wrapped by header, trailer etc. In redpanda we were seeing
about 3-4 fragments per packet and hence the same factor of overhead in
terms of `sendmsg` syscalls.

To avoid this issue this patch linearizes the `net::packet` if it's
below the TLS max record size. This forces a single pass through the
whole machinery for smallish packets. Note there is many variations one
could do here but this seems like the safest to avoid running into edge
cases where linearization would actually make things worse.

There certainly is room for further improvement in the TLS
implementation. For example one could batch in the push function instead
of forwarding data to `sendmsg` unconditionally. However at larger send
sizes the syscall overhead should be less of an issue.

This patch improves performance quite measurably.

Below is data for a Redpanda OMB benchmark @ 512MB/s with 50 producers
and 50 consumers (~11KB batch size). This is on 3xi3en.6xlarge brokers.

Aggregated e2e latency changes (numbers are fairly stable compared to
the changes):

p50: 7.2ms -> 5.6ms
p99: 35ms -> 15ms
p999: 74ms -> 43ms

At the same time reactor utilization goes down by ~3%. Note due to how
batching works this is while doing ~5% more RPS (with decresed batch
size).

We can further confirm that the amount of `sendmsg` syscalls we do is
down by a factor of ~3 (before vs. with this patch):

```
ubuntu@ip-172-31-16-29:~$ sudo perf stat -e 'syscalls:sys_enter_sendmsg' -p $(pidof redpanda) -r 5 -- sleep 10

 Performance counter stats for process id '14046' (5 runs):

           2790664      syscalls:sys_enter_sendmsg                                     ( +-  0.18% )

ubuntu@ip-172-31-16-29:~$ sudo perf stat -e 'syscalls:sys_enter_sendmsg' -p $(pidof redpanda) -r 5 -- sleep 10

 Performance counter stats for process id '17479' (5 runs):

            989158      syscalls:sys_enter_sendmsg                                     ( +-  0.21% )
```