### PR TITLE
[v23.3.x] Pull in upstream versions of TLS & epoll changes

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -876,13 +876,14 @@ reactor_backend_epoll::wait_and_process(int timeout, const sigset_t* active_sigm
             _steady_clock_timer_deadline = {};
             continue;
         }
-        if (evt.events & (EPOLLHUP | EPOLLERR)) {
+        bool has_error = evt.events & (EPOLLHUP | EPOLLERR);
+        if (has_error) {
             // treat the events as required events when error occurs, let
             // send/recv/accept/connect handle the specific error.
             evt.events = pfd->events_requested;
         }
         auto events = evt.events & (EPOLLIN | EPOLLOUT | EPOLLRDHUP);
-        auto events_to_remove = events & ~pfd->events_requested;
+        auto events_to_remove = has_error ? pfd->events_requested : events & ~pfd->events_requested;
         complete_epoll_event(*pfd, events, EPOLLRDHUP);
         if (pfd->events_rw) {
             // accept() signals normal completions via EPOLLIN, but errors (due to shutdown())

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -876,12 +876,10 @@ reactor_backend_epoll::wait_and_process(int timeout, const sigset_t* active_sigm
             _steady_clock_timer_deadline = {};
             continue;
         }
-        bool has_error = false;
         if (evt.events & (EPOLLHUP | EPOLLERR)) {
             // treat the events as required events when error occurs, let
             // send/recv/accept/connect handle the specific error.
             evt.events = pfd->events_requested;
-            has_error = true;
         }
         auto events = evt.events & (EPOLLIN | EPOLLOUT | EPOLLRDHUP);
         auto events_to_remove = events & ~pfd->events_requested;
@@ -902,18 +900,6 @@ reactor_backend_epoll::wait_and_process(int timeout, const sigset_t* active_sigm
             evt.events = pfd->events_epoll;
             auto op = evt.events ? EPOLL_CTL_MOD : EPOLL_CTL_DEL;
             ::epoll_ctl(_epollfd.get(), op, pfd->fd.get(), &evt);
-        }
-        else if (has_error && pfd->events_requested == 0) {
-            // In case we got an error and we are not interested in any events
-            // anymore, remove the fd from the epoll set. Otherwise due to the
-            // above logic of setting evt.events to pfd->events_requested (0)
-            // and subsequent calculation of events_to_remove, we would never
-            // remove the fd from the epoll set. Due to running in level
-            // triggered mode this would then cause repeated wake ups and
-            // spinning until the fd is closed and thereby removed from the
-            // epoll set.
-            pfd->events_epoll = 0;
-            ::epoll_ctl(_epollfd.get(), EPOLL_CTL_DEL, pfd->fd.get(), nullptr);
         }
     }
     return nr;

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1479,18 +1479,6 @@ public:
                return put(std::move(p));
             });
         }
-
-        // We want to make sure that we call gnutls_record_send with as large
-        // packets as possible. This is because each call to gnutls_record_send
-        // translates to a sendmsg syscall. Further it results in larger TLS
-        // records which makes encryption/decryption faster. Hence to avoid
-        // cases where we would do an extra syscall for something like a 100
-        // bytes header we linearize the packet if it's below the max TLS record
-        // size.
-        if (p.nr_frags() > 1 && p.len() <= 16384) {
-            p.linearize();
-        }
-
         auto i = p.fragments().begin();
         auto e = p.fragments().end();
         return with_semaphore(_out_sem, 1, std::bind(&session::do_put, this, i, e)).finally([p = std::move(p)] {});

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1479,6 +1479,18 @@ public:
                return put(std::move(p));
             });
         }
+
+        // We want to make sure that we call gnutls_record_send with as large
+        // packets as possible. This is because each call to gnutls_record_send
+        // translates to a sendmsg syscall. Further it results in larger TLS
+        // records which makes encryption/decryption faster. Hence to avoid
+        // cases where we would do an extra syscall for something like a 100
+        // bytes header we linearize the packet if it's below the max TLS record
+        // size.
+        if (p.nr_frags() > 1 && p.len() <= gnutls_record_get_max_size(*this)) {
+            p.linearize();
+        }
+
         auto i = p.fragments().begin();
         auto e = p.fragments().end();
         return with_semaphore(_out_sem, 1, std::bind(&session::do_put, this, i, e)).finally([p = std::move(p)] {});


### PR DESCRIPTION
Update two of our patches as per upstream.

There is no real functional difference.