### PR TITLE
Use ad-hoc free function for liburing probe

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -1255,7 +1255,7 @@ try_create_uring(unsigned queue_len, bool throw_on_error) {
         maybe_throw(std::runtime_error("unable to create io_uring probe"));
         return std::nullopt;
     }
-    auto free_probe = defer([&] () noexcept { ::free(probe); });
+    auto free_probe = defer([&] () noexcept { ::io_uring_free_probe(probe); });
 
     for (auto op : required_ops) {
         if (!io_uring_opcode_supported(probe, op)) {


### PR DESCRIPTION
This will be needed for liburing > 2.2, and is more correct anyway.

Also, it may need to be cherry-picked on other vX.Y.Z branches.
