### PR TITLE
Fix edge case in memory sampler at OOM

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1575,8 +1575,11 @@ void* allocate_from_sampled_small_pool(size_t size) {
     auto& pool = get_cpu_mem().sampled_small_pools[idx];
     dassert(size <= pool.object_size());
     void* ptr = pool.allocate();
-    auto alloc_site = get_cpu_mem().add_alloc_site(pool.object_size());
-    new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
+    if (__builtin_expect(ptr != nullptr, true)) {
+        // we failed to allocate, so we won't sample either
+        auto alloc_site = get_cpu_mem().add_alloc_site(pool.object_size());
+        new (&pool.alloc_site_holder(ptr)) allocation_site_ptr{alloc_site};
+    }
     return ptr;
 }
 


### PR DESCRIPTION
In one place in the memory sampling code we assume a non-null pointer
but if the system is out of memory this pointer may be null.

When using abort-on-bad-alloc this scenario is extremely unlikely since
the first failed allocation would have to meet very specific conditions
for this to occur: be a small allocation and be sampled, which is
unlikely since larger allocations usually fail first (and small pools
ask the underlying allocator for at most 128K at a time).

Discovered while analyzing https://github.com/redpanda-data/redpanda/issues/15711.