### PR TITLE
reactor: Print correct errno on io_submit failure

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -184,8 +184,7 @@ aio_storage_context::handle_aio_error(linux_abi::iocb* iocb, int ec) {
         }
         default:
             ++_r._io_stats.aio_errors;
-            throw_system_error_on(true, "io_submit");
-            abort();
+            throw std::system_error(ec, std::system_category(), "io_submit");
     }
 }
 


### PR DESCRIPTION
Backport https://github.com/scylladb/seastar/pull/2123

When encountering an `io_submit` error in the `storage_context` we call `handle_aio_error` to handle said error.

First we check for `EAGAIN` and `EBADF` and handle those separately. For other errors we would call `throw_system_error_on` to throw an exception.

This was bugged because `throw_system_error_on` reads errno directly which means it might potentially print the wrong error code as errno might have changed from the error code that we passed to `handle_aio_error`. This can happen in the aio systemcall fallback thread where the io_submit error is handled only later after possibly suspending.

To fix this we just throw an exception in `handle_aio_error` directly and pass the correct error code.

`throw_system_error_on` checks for a condition but we pass `true` unconditionally. Further it checks for `EBADF` and `ENOTSOCK` and possibly aborts in those cases. However, we have already checked for `EBADF` and `ENOTSOCK` is not a valid return code for `io_submit`. Note these later checks are also bugged as they again use `errno` so might possibly abort when they shouldn't.

This also allows us to remove the abort at the end of the switch default case which was needed to satisfy the compiler.

(cherry picked from commit 1883ccf7e15d9e945b33a4c03850155cc62a9105)