### PR TITLE
http/util: add path_decode method

### DIFF
--- a/include/seastar/http/common.hh
+++ b/include/seastar/http/common.hh
@@ -58,6 +58,16 @@ public:
         return path(key);
     }
 
+    std::unordered_map<sstring, sstring>::const_iterator
+    find(const sstring& key) const {
+        return params.find(key);
+    }
+
+    std::unordered_map<sstring, sstring>::const_iterator
+    end() const {
+        return params.end();
+    }
+
     bool exists(const sstring& key) const {
         return params.find(key) != params.end();
     }

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -109,12 +109,12 @@ struct request {
     }
 
     /**
-     * Search for the first header of a given name
-     * @param name the header name
-     * @return a pointer to the header value, if it exists or empty string
+     * Search for the last query parameter of a given key
+     * @param key the query paramerter key
+     * @return the query parameter value, if it exists or empty string
      */
-    sstring get_query_param(const sstring& name) const {
-        auto res = query_parameters.find(name);
+    sstring get_query_param(const sstring& key) const {
+        auto res = query_parameters.find(key);
         if (res == query_parameters.end()) {
             return "";
         }
@@ -284,7 +284,7 @@ struct request {
     static request make(httpd::operation_type type, sstring host, sstring path);
 
 private:
-    void add_param(const std::string_view& param);
+    void add_query_param(const std::string_view& param);
     sstring request_line() const;
     future<> write_request_headers(output_stream<char>& out);
     friend class experimental::connection;

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -37,6 +37,7 @@
 #include <strings.h>
 #include <seastar/http/common.hh>
 #include <seastar/http/mime_types.hh>
+#include <seastar/http/url.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/util/string_utils.hh>
@@ -119,6 +120,26 @@ struct request {
             return "";
         }
         return res->second;
+    }
+
+    /**
+     * Search for the last path parameter of a given key
+     * @param key the path paramerter key
+     * @return the unescaped path parameter value, if it exists and can be path decoded successfully, otherwise it
+     *  returns an empty string
+     */
+    sstring get_path_param(const sstring& key) const {
+        auto res = param.find(key);
+        if (res == param.end()) {
+            return "";
+        }
+        auto& raw_path_param = res->second;
+        auto decoded_path_param = sstring{};
+        auto ok = internal::path_decode(raw_path_param, decoded_path_param);
+        if (!ok) {
+            return "";
+        }
+        return decoded_path_param;
     }
 
     /**

--- a/include/seastar/http/url.hh
+++ b/include/seastar/http/url.hh
@@ -28,6 +28,8 @@ namespace internal {
 
 bool url_decode(const std::string_view& in, sstring& out);
 
+bool path_decode(const std::string_view& in, sstring& out);
+
 /**
  * Makes a percent-encoded string out of the given parameter
  *

--- a/include/seastar/http/url.hh
+++ b/include/seastar/http/url.hh
@@ -26,9 +26,9 @@ namespace seastar {
 namespace http {
 namespace internal {
 
-bool url_decode(const std::string_view& in, sstring& out);
+bool url_decode(std::string_view in, sstring& out);
 
-bool path_decode(const std::string_view& in, sstring& out);
+bool path_decode(std::string_view in, sstring& out);
 
 /**
  * Makes a percent-encoded string out of the given parameter
@@ -38,7 +38,7 @@ bool path_decode(const std::string_view& in, sstring& out);
  * the URL into path and arguments (both names and values) and use
  * this helper to encode individual strings
  */
-sstring url_encode(const std::string_view& in);
+sstring url_encode(std::string_view in);
 
 } // internal namespace
 } // http namespace

--- a/src/http/request.cc
+++ b/src/http/request.cc
@@ -63,7 +63,7 @@ future<> request::write_request_headers(output_stream<char>& out) {
     });
 }
 
-void request::add_param(const std::string_view& param) {
+void request::add_query_param(const std::string_view& param) {
     size_t split = param.find('=');
 
     if (split >= param.length() - 1) {
@@ -91,10 +91,10 @@ sstring request::parse_query_param() {
     size_t end_param;
     std::string_view url = _url;
     while ((end_param = _url.find('&', curr)) != sstring::npos) {
-        add_param(url.substr(curr, end_param - curr) );
+        add_query_param(url.substr(curr, end_param - curr) );
         curr = end_param + 1;
     }
-    add_param(url.substr(curr));
+    add_query_param(url.substr(curr));
     return _url.substr(0, pos);
 }
 

--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -67,9 +67,8 @@ inline char char_to_hex(unsigned char val) {
     return "0123456789ABCDEF"[val];
 }
 
-}
-
-bool url_decode(const std::string_view& in, sstring& out) {
+template<bool ReplacePlus>
+bool decode(const std::string_view& in, sstring& out) {
     size_t pos = 0;
     sstring buff(in.length(), 0);
     for (size_t i = 0; i < in.length(); ++i) {
@@ -80,7 +79,7 @@ bool url_decode(const std::string_view& in, sstring& out) {
             } else {
                 return false;
             }
-        } else if (in[i] == '+') {
+        } else if (ReplacePlus && in[i] == '+') {
             buff[pos++] = ' ';
         } else {
             buff[pos++] = in[i];
@@ -90,6 +89,17 @@ bool url_decode(const std::string_view& in, sstring& out) {
     out = buff;
     return true;
 }
+
+}
+
+bool url_decode(const std::string_view& in, sstring& out) {
+    return decode<true>(in, out);
+}
+
+bool path_decode(const std::string_view& in, sstring& out) {
+    return decode<false>(in, out);
+}
+
 
 sstring url_encode(const std::string_view& in) {
     size_t encodable_chars = 0;

--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -67,8 +67,7 @@ inline char char_to_hex(unsigned char val) {
     return "0123456789ABCDEF"[val];
 }
 
-template<bool ReplacePlus>
-bool decode(const std::string_view& in, sstring& out) {
+bool decode(bool replace_plus, const std::string_view& in, sstring& out) {
     size_t pos = 0;
     sstring buff(in.length(), 0);
     for (size_t i = 0; i < in.length(); ++i) {
@@ -79,7 +78,7 @@ bool decode(const std::string_view& in, sstring& out) {
             } else {
                 return false;
             }
-        } else if (ReplacePlus && in[i] == '+') {
+        } else if (replace_plus && in[i] == '+') {
             buff[pos++] = ' ';
         } else {
             buff[pos++] = in[i];
@@ -93,11 +92,11 @@ bool decode(const std::string_view& in, sstring& out) {
 }
 
 bool url_decode(std::string_view in, sstring& out) {
-    return decode<true>(in, out);
+    return decode(true, in, out);
 }
 
 bool path_decode(std::string_view in, sstring& out) {
-    return decode<false>(in, out);
+    return decode(false, in, out);
 }
 
 

--- a/src/http/url.cc
+++ b/src/http/url.cc
@@ -49,7 +49,7 @@ short hex_to_byte(char c) {
 /**
  * Convert a hex encoded 2 bytes substring to char
  */
-char hexstr_to_char(const std::string_view& in, size_t from) {
+char hexstr_to_char(std::string_view in, size_t from) {
 
     return static_cast<char>(hex_to_byte(in[from]) * 16 + hex_to_byte(in[from + 1]));
 }
@@ -92,16 +92,16 @@ bool decode(const std::string_view& in, sstring& out) {
 
 }
 
-bool url_decode(const std::string_view& in, sstring& out) {
+bool url_decode(std::string_view in, sstring& out) {
     return decode<true>(in, out);
 }
 
-bool path_decode(const std::string_view& in, sstring& out) {
+bool path_decode(std::string_view in, sstring& out) {
     return decode<false>(in, out);
 }
 
 
-sstring url_encode(const std::string_view& in) {
+sstring url_encode(std::string_view in) {
     size_t encodable_chars = 0;
     for (size_t i = 0; i < in.length(); i++) {
         if (should_encode(in[i])) {

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1407,3 +1407,24 @@ SEASTAR_TEST_CASE(test_url_param_encode_decode) {
 
     return make_ready_future<>();
 }
+
+BOOST_AUTO_TEST_CASE(test_path_decode_unchanged) {
+    auto unchanged_chars = seastar::sstring{
+      "~abcdefghijklmnopqrstuvwhyz-ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789.+"};
+    auto result = seastar::sstring{};
+    auto success = http::internal::path_decode(unchanged_chars, result);
+
+    BOOST_REQUIRE(success);
+    BOOST_REQUIRE_EQUAL(result, unchanged_chars);
+}
+
+BOOST_AUTO_TEST_CASE(test_path_decode_changed) {
+    auto changed_chars = seastar::sstring{"%20"};
+    auto result = seastar::sstring{};
+    auto success = http::internal::path_decode(changed_chars, result);
+
+    BOOST_REQUIRE(success);
+
+    auto expected_chars = seastar::sstring{" "};
+    BOOST_REQUIRE_EQUAL(result, expected_chars);
+}

--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -205,6 +205,24 @@ SEASTAR_TEST_CASE(test_decode_url) {
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_decode_path) {
+    http::request req;
+    req.param = httpd::parameters();
+    req.param.set("param1", "a+b");
+    req.param.set("param2", "same%2Ba%2Bb");
+    req.param.set("param3", "another_param");
+    req.param.set("param4", "yet%20another");
+    req.param.set("invalid_param", "%2");
+
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param1"), "a+b");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param2"), "same+a+b");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param3"), "another_param");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("param4"), "yet another");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("invalid_param"), "");
+    BOOST_REQUIRE_EQUAL(req.get_path_param("missing_param"), "");
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_routes) {
     handl* h1 = new handl();
     handl* h2 = new handl();


### PR DESCRIPTION
Some REST APIs of Redpanda were incorrectly using the `url_decode` method to decode path parameters. This caused issues for Redpanda's clients as they were unable to delete users that had a '+' in the username. As part of solving the decoding, I introduced a `path_decode` method, and it would be most convenient if this method lived next to the existing `url_decode` utility method that `seastar` provides both to enable code reuse and to bring it to users' attention that they should make a conscious choice between the two decode methods.

Therefore, this PR ports this `url_decode` method over to the `seastar` library.

Related PR: https://github.com/redpanda-data/redpanda/pull/16694