### PR TITLE
core/internal/timers: Add  timers missing include

### DIFF
--- a/include/seastar/core/internal/timers.hh
+++ b/include/seastar/core/internal/timers.hh
@@ -22,6 +22,7 @@
 #pragma once
 
 #ifndef SEASTAR_MODULE
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <optional>


### PR DESCRIPTION
Followup to #48 

Spotted with Clang 18

