### PR TITLE
Add mTLS auth to the TLS implementation backed by OpenSSL

### DIFF
--- a/demos/tls_echo_server.hh
+++ b/demos/tls_echo_server.hh
@@ -54,6 +54,9 @@ public:
 
     future<> listen(socket_address addr, sstring crtfile, sstring keyfile, tls::client_auth ca = tls::client_auth::NONE) {
         _certs->set_client_auth(ca);
+        _certs->set_dn_verification_callback([](seastar::tls::session_type, sstring subject, sstring issuer){
+            std::cout << "DN Verification callback, subject: " << subject << " issuer: " << issuer << std::endl;
+        });
         return _certs->set_x509_key_file(crtfile, keyfile, tls::x509_crt_format::PEM).then([this, addr] {
             ::listen_options opts;
             opts.reuse_address = true;

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -324,6 +324,13 @@ public:
     void dh_params(const tls::dh_params&) {}
 
     std::vector<cert_info> get_x509_info() const {
+        if (_server_creds.cert) {
+            return {
+                cert_info{
+                    .serial = extract_x509_serial(_server_creds.cert.get()),
+                    .expiry = extract_x509_expiry(_server_creds.cert.get())}
+            };
+        }
         return {};
     }
 

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -26,6 +26,8 @@ module;
 #include <system_error>
 
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/x509_vfy.h>
 #include <openssl/err.h>
 #include <openssl/provider.h>
 #include <openssl/safestack.h>
@@ -86,6 +88,12 @@ private:
     }
 };
 
+template<typename T>
+sstring asn1_str_to_str(T* asn1) {
+    const auto len = ASN1_STRING_length(asn1);
+    return sstring((char*)ASN1_STRING_get0_data(asn1), len);
+};
+
 template<typename T, auto fn>
 struct ssl_deleter {
     void operator()(T* ptr) { fn(ptr); }
@@ -94,6 +102,10 @@ struct ssl_deleter {
 // Must define this method as sk_X509_pop_free is a macro
 void X509_pop_free(STACK_OF(X509)* ca) {
     sk_X509_pop_free(ca, X509_free);
+}
+
+void GENERAL_NAME_pop_free(GENERAL_NAMES* gns) {
+    sk_GENERAL_NAME_pop_free(gns, GENERAL_NAME_free);
 }
 
 template<typename T, auto fn>
@@ -106,6 +118,8 @@ using x509_crl_ptr = ssl_handle<X509_CRL, X509_CRL_free>;
 using x509_store_ptr = ssl_handle<X509_STORE, X509_STORE_free>;
 using x509_store_ctx_ptr = ssl_handle<X509_STORE_CTX, X509_STORE_CTX_free>;
 using x509_chain_ptr = ssl_handle<STACK_OF(X509), X509_pop_free>;
+using x509_extension_ptr = ssl_handle<X509_EXTENSION, X509_EXTENSION_free>;
+using general_names_ptr = ssl_handle<GENERAL_NAMES, GENERAL_NAME_pop_free>;
 using pkcs12 = ssl_handle<PKCS12, PKCS12_free>;
 using ssl_ctx_ptr = ssl_handle<SSL_CTX, SSL_CTX_free>;
 using ssl_ptr = ssl_handle<SSL, SSL_free>;
@@ -869,12 +883,118 @@ public:
         return make_ready_future<result_t>(std::move(dn));
     }
 
-    future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type>) override {
+    future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) override {
         using result_t = std::vector<subject_alt_name>;
-        return make_exception_future<result_t>(std::runtime_error("unimplemented"));
+
+        if (_error) {
+            return make_exception_future<result_t>(_error);
+        }
+        if (_shutdown) {
+            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
+        }
+        if (!connected()) {
+            return handshake().then([this, types = std::move(types)]() mutable {
+               return get_alt_name_information(std::move(types));
+            });
+        }
+
+        const auto& peer_cert = get_peer_certificate();
+        if (!peer_cert) {
+            return make_ready_future<result_t>();
+        }
+        return make_ready_future<result_t>(do_get_alt_name_information(peer_cert, types));
     }
 
 private:
+    std::vector<subject_alt_name> do_get_alt_name_information(const x509_ptr &peer_cert,
+                                                              const std::unordered_set<subject_alt_name_type> &types) const {
+        int ext_idx = X509_get_ext_by_NID(peer_cert.get(), NID_subject_alt_name, -1);
+        if (ext_idx < 0) {
+            return {};
+        }
+        auto ext = x509_extension_ptr(X509_get_ext(peer_cert.get(), ext_idx));
+        if (!ext) {
+            return {};
+        }
+        auto names = general_names_ptr((GENERAL_NAMES*)X509V3_EXT_d2i(ext.get()));
+        if (!names) {
+            return {};
+        }
+        int num_names = sk_GENERAL_NAME_num(names.get());
+        std::vector<subject_alt_name> alt_names;
+        alt_names.reserve(num_names);
+
+        for (auto i = 0; i < num_names; i++) {
+            GENERAL_NAME *name = sk_GENERAL_NAME_value(names.get(), i);
+            if (auto known_t = field_to_san_type(name)) {
+                if (types.empty() || types.count(known_t->type)) {
+                    alt_names.push_back(std::move(*known_t));
+                }
+            }
+        }
+        return alt_names;
+    }
+
+    std::optional<subject_alt_name> field_to_san_type(GENERAL_NAME* name) const {
+        subject_alt_name san;
+        switch(name->type) {
+            case GEN_IPADD:
+            {
+                san.type = subject_alt_name_type::ipaddress;
+                const auto* data = ASN1_STRING_get0_data(name->d.iPAddress);
+                const auto size = ASN1_STRING_length(name->d.iPAddress);
+                if (size == sizeof(::in_addr)) {
+                    ::in_addr addr;
+                    memcpy(&addr, data, size);
+                    san.value = net::inet_address(addr);
+                } else if (size == sizeof(::in6_addr)) {
+                    ::in6_addr addr;
+                    memcpy(&addr, data, size);
+                    san.value = net::inet_address(addr);
+                } else {
+                    throw std::runtime_error(fmt::format("Unexpected size: {} for ipaddress alt name value", size));
+                }
+                break;
+            }
+            case GEN_EMAIL:
+            {
+                san.type = subject_alt_name_type::rfc822name;
+                san.value = asn1_str_to_str(name->d.rfc822Name);
+                break;
+            }
+            case GEN_URI:
+            {
+                san.type = subject_alt_name_type::uri;
+                san.value = asn1_str_to_str(name->d.uniformResourceIdentifier);
+                break;
+            }
+            case GEN_DNS:
+            {
+                san.type = subject_alt_name_type::dnsname;
+                san.value = asn1_str_to_str(name->d.dNSName);
+                break;
+            }
+            case GEN_OTHERNAME:
+            {
+                san.type = subject_alt_name_type::othername;
+                san.value = asn1_str_to_str(name->d.dNSName);
+                break;
+            }
+            case GEN_DIRNAME:
+            {
+                san.type = subject_alt_name_type::dn;
+                auto dirname = get_ossl_string(name->d.directoryName);
+                if (!dirname) {
+                    throw std::runtime_error("Expected non null value for SAN dirname");
+                }
+                san.value = std::move(*dirname);
+                break;
+            }
+            default:
+                return std::nullopt;
+        }
+        return san;
+    }
 
     const x509_ptr& get_peer_certificate() const {
         return _creds->get_last_cert();

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -584,7 +584,7 @@ public:
                     case SSL_ERROR_WANT_READ:
                         return pull_encrypted_and_send();
                     case SSL_ERROR_WANT_WRITE:
-                        break;
+                        return wait_for_input();
                     case SSL_ERROR_SSL:
                     {
                         // Catch-all for handshake errors

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -46,6 +46,7 @@ module seastar;
 #include <seastar/core/gate.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/util/later.hh>
+#include <seastar/util/defer.hh>
 #endif
 
 namespace seastar {
@@ -584,11 +585,29 @@ public:
                         return pull_encrypted_and_send();
                     case SSL_ERROR_WANT_WRITE:
                         break;
+                    case SSL_ERROR_SSL:
+                    {
+                        // Catch-all for handshake errors
+                        auto ec = ERR_GET_REASON(ERR_get_error())
+                        switch (ec) {
+                        case SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE:
+                        case SSL_R_CERTIFICATE_VERIFY_FAILED:
+                        case SSL_R_NO_CERTIFICATES_RETURNED:
+                            verify(); // should throw
+                            [[fallthrough]];
+                        default:
+                            return make_exception_future<>(ossl_error("Failed to establish SSL handshake"));
+                        }
+                    }
                     default:
-                        return make_exception_future<>(ossl_error("Failed to establish SSL handshake"));
+                        return make_exception_future<>(ossl_error("Unhandled error code observed"));
                     }
                     return make_ready_future<>();
                 });
+            }).then([this]{
+                if (_type == session_type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
+                    verify();
+                }
             });
     }
 
@@ -703,6 +722,37 @@ public:
         return make_exception_future<>(ossl_error("fatal error during ssl shutdown"));
     }
 
+    void verify() {
+        // A success return code (0) does not signify if a cert was presented or not, that
+        // must be explicitly queried via SSL_get_peer_certificate
+        auto res = SSL_get_verify_result(_ssl.get());
+        if (res != X509_V_OK) {
+            sstring stat_str(X509_verify_cert_error_string(res));
+            auto dn = extract_dn_information();
+            if (dn) {
+                std::stringstream ss;
+                ss << stat_str;
+                if (stat_str.back() != ' ') {
+                    ss << ' ';
+                }
+                ss << "(Issuer=[" << dn->issuer << "], Subject=[" << dn->subject << "])";
+                stat_str = ss.str();
+            }
+            throw verification_error(stat_str);
+        } else if (SSL_get0_peer_certificate(_ssl.get()) == nullptr) {
+            if (_type == session_type::SERVER && _creds->get_client_auth() == client_auth::REQUIRE) {
+                throw verification_error("no certificate presented");
+            }
+            return;
+        }
+
+        if (_creds->_dn_callback) {
+            auto dn = extract_dn_information();
+            assert(dn.has_value());
+            _creds->_dn_callback(_type, std::move(dn->subject), std::move(dn->issuer));
+        }
+    }
+
     bool eof() const {
         return _eof;
     }
@@ -812,10 +862,23 @@ public:
         return make_exception_future<result_t>(std::runtime_error("unimplemented"));
     }
 
-
 private:
+
+    const x509_ptr& get_peer_certificate() const {
+        return _creds->get_last_cert();
+    }
+
     std::optional<session_dn> extract_dn_information() const {
-        return std::nullopt;
+        const auto& peer_cert = get_peer_certificate();
+        if (!peer_cert) {
+            return std::nullopt;
+        }
+        auto subject = get_ossl_string(X509_get_subject_name(peer_cert.get()));
+        auto issuer = get_ossl_string(X509_get_issuer_name(peer_cert.get()));
+        if(!subject || !issuer) {
+            throw ossl_error("error while extracting certificate DN strings");
+        }
+        return session_dn{.subject= std::move(*subject), .issuer = std::move(*issuer)};
     }
 
     ssl_ctx_ptr make_ssl_context(){
@@ -824,10 +887,20 @@ private:
             throw ossl_error("Failed to initialize SSL context");
         }
 
-        SSL_CTX_set_verify(ssl_ctx.get(), SSL_VERIFY_NONE, nullptr);
-        SSL_CTX_set1_cert_store(_ctx.get(), *_creds);
-
         if (_type == session_type::SERVER) {
+            switch(_creds->get_client_auth()) {
+                case client_auth::NONE:
+                default:
+                    SSL_CTX_set_verify(_ctx.get(), SSL_VERIFY_NONE, nullptr);
+                    break;
+                case client_auth::REQUEST:
+                    SSL_CTX_set_verify(_ctx.get(), SSL_VERIFY_PEER, nullptr);
+                    break;
+                case client_auth::REQUIRE:
+                    SSL_CTX_set_verify(_ctx.get(), SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+                    break;
+            }
+
             auto& server_creds = _creds->get_server_credentials();
             if (server_creds.key == nullptr || server_creds.cert == nullptr) {
                 throw ossl_error("Cannot start session without cert/key pair for server");
@@ -836,7 +909,21 @@ private:
                 throw ossl_error("Failed to load cert/key pair");
             }
         }
+        // Increments the reference count of *_creds, now should have a total ref count of two, will be deallocated
+        // when both OpenSSL and the certificate_manager call X509_STORE_free
+        SSL_CTX_set1_cert_store(_ctx.get(), *_creds);
         return ssl_ctx;
+    }
+
+    static std::optional<sstring> get_ossl_string(X509_NAME* name){
+        if (auto name_str = X509_NAME_oneline(name, nullptr, 0)) {
+            // sstring constructor may throw, to ensure deallocation of this OpenSSL string in
+            // all cases, wrap the call to free() in a deferred_action
+            auto done = defer([&name_str]() noexcept { OPENSSL_free(name_str); });
+            sstring ossl_str(name_str);
+            return ossl_str;
+        }
+        return std::nullopt;
     }
 
 private:


### PR DESCRIPTION
Adds support for mTLS clients. This works by setting invoking the `set_client_auth` field to `REQUIRED`. 

Also implemented the ossl analogue to the original `session::verify` method, which parses the subject and issuer from the cert checking for validity and optionally returning that info via a preregistered callback (`set_dn_callback`)

https://github.com/redpanda-data/core-internal/issues/1091