### PR TITLE
tls: Include trust file contents with reload callback

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -277,7 +277,7 @@ namespace tls {
     class reloadable_credentials_base;
 
     using reload_callback = std::function<void(const std::unordered_set<sstring>&, std::exception_ptr)>;
-    using reload_callback_with_creds = std::function<void(const std::unordered_set<sstring>&, const certificate_credentials&, std::exception_ptr)>;
+    using reload_callback_with_creds = std::function<void(const std::unordered_set<sstring> &, const certificate_credentials &, std::exception_ptr, std::optional<blob>)>;
 
     /**
      * Intentionally "primitive", and more importantly, copyable
@@ -318,6 +318,8 @@ namespace tls {
         future<shared_ptr<certificate_credentials>> build_reloadable_certificate_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
         future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback = {}, std::optional<std::chrono::milliseconds> tolerance = {}) const;
         future<shared_ptr<server_credentials>> build_reloadable_server_credentials(reload_callback_with_creds, std::optional<std::chrono::milliseconds> tolerance = {}) const;
+
+        std::optional<blob> get_trust_file_blob() const;
     private:
         friend class reloadable_credentials_base;
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -208,7 +208,8 @@ static auto get_gtls_string = [](auto func, auto... args) noexcept {
 tls::reload_callback_with_creds wrap_reload_callback(tls::reload_callback cb) {
     return [cb{std::move(cb)}](const std::unordered_set<sstring> &files,
                                const tls::certificate_credentials&,
-                               std::exception_ptr ep) {
+                               std::exception_ptr ep,
+                               std::optional<tls::blob>) {
         return cb(files, ep);
     };
 }
@@ -977,7 +978,7 @@ public:
         void do_callback(std::exception_ptr ep = {}) {
             if (_cb && !_files.empty() && _creds) {
                 const auto &creds = _creds->as_certificate_credentials();
-                _cb(boost::copy_range<std::unordered_set<sstring>>(_files | boost::adaptors::map_keys), creds, std::move(ep));
+                _cb(boost::copy_range<std::unordered_set<sstring>>(_files | boost::adaptors::map_keys), creds, std::move(ep), get_trust_file_blob());
             }
         }
         // called from seastar::thread
@@ -1090,6 +1091,13 @@ future<shared_ptr<tls::server_credentials>> tls::credentials_builder::build_relo
     return creds->init().then([creds] {
         return make_ready_future<shared_ptr<tls::server_credentials>>(creds);
     });
+}
+
+std::optional<tls::blob> tls::credentials_builder::get_trust_file_blob() const {
+    if (auto i = _blobs.find(x509_trust_key); i != _blobs.end()) {
+        return std::make_optional<tls::blob>(boost::any_cast<const x509_simple&>(i->second).data);
+    }
+    return std::nullopt;
 }
 
 namespace tls {

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -986,7 +986,8 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_creds) {
 
     auto certs = b.build_reloadable_server_credentials([&](const std::unordered_set<sstring> &files,
                                                            const tls::certificate_credentials &creds,
-                                                           std::exception_ptr ep) {
+                                                           std::exception_ptr ep,
+                                                           std::optional<tls::blob> trust_file_contents) {
         if (ep) {
             return;
         }
@@ -1001,6 +1002,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_creds) {
 
         BOOST_CHECK(certs_info.has_value() && !certs_info.value().empty());
         BOOST_CHECK(trust_list_info.has_value() && trust_list_info.value().empty());
+        BOOST_CHECK(!trust_file_contents.has_value());
 
     }).get0();
 
@@ -1011,6 +1013,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_creds) {
 
     BOOST_CHECK(certs_info.has_value() && !certs_info.value().empty());
     BOOST_CHECK(trust_list_info.has_value());
+    BOOST_CHECK(!b.get_trust_file_blob().has_value());
 
     // copy the right (trusted) certs over the old ones.
     fs::copy_file(certfile("test.crt"), tmp.path() / "test0.crt");


### PR DESCRIPTION
Passed up to application code as a tls::blob (basic_string_view<char>).

Also provide the ability to fetch this blob directly via credentials_builder::get_trust_file_blob()

Updates unit tests to accommodate the new reload callback signature.

Required for https://github.com/redpanda-data/redpanda/pull/17539