### PR TITLE
Supports for TLS clients within the OpenSSL TLS implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -857,6 +857,7 @@ target_compile_options (seastar
 target_compile_definitions(seastar
   PUBLIC
   SEASTAR_API_LEVEL=${Seastar_API_LEVEL}
+  $<$<BOOL:${Seastar_WITH_OSSL}>:SEASTAR_WITH_TLS_OSSL=1>
   $<$<BOOL:${BUILD_SHARED_LIBS}>:SEASTAR_BUILD_SHARED_LIBS>)
 
 target_compile_features(seastar

--- a/demos/tls_echo_server.hh
+++ b/demos/tls_echo_server.hh
@@ -46,74 +46,86 @@ class echoserver {
     seastar::gate _gate;
     bool _stopped = false;
     bool _verbose = false;
+
+    future<stop_iteration> run_once() {
+        if (_stopped) {
+            return make_ready_future<stop_iteration>(stop_iteration::yes);
+        }
+        return with_gate(_gate, [this] {
+            return _socket.accept().then([this](accept_result ar) {
+                ::connected_socket s = std::move(ar.connection);
+                    socket_address a = std::move(ar.remote_address);
+                    if (_verbose) {
+                        std::cout << "Got connection from "<< a << std::endl;
+                    }
+                    auto strms = make_lw_shared<streams>(std::move(s));
+                    return repeat([strms, this]() {
+                        return strms->in.read().then([this, strms](temporary_buffer<char> buf) {
+                            if (buf.empty()) {
+                                if (_verbose) {
+                                    std::cout << "EOM" << std::endl;
+                                }
+                                return make_ready_future<stop_iteration>(stop_iteration::yes);
+                            }
+                            sstring tmp(buf.begin(), buf.end());
+                            if (_verbose) {
+                                std::cout << "Read " << tmp.size() << "B" << std::endl;
+                            }
+                            return strms->out.write(tmp).then([strms]() {
+                                return strms->out.flush();
+                            }).then([] {
+                                return make_ready_future<stop_iteration>(stop_iteration::no);
+                            });
+                        });
+                    }).then([strms]{
+                        return strms->out.close();
+                    }).handle_exception([](auto ep) {
+                        std::cout << "Exception: " << ep << std::endl;
+                    }).finally([this, strms]{
+                        if (_verbose) {
+                            std::cout << "Ending session" << std::endl;
+                        }
+                        return strms->in.close();
+                    });
+            }).handle_exception([this](auto ep) {
+                if (!_stopped) {
+                    std::cerr << "Error: " << ep << std::endl;
+                }
+            }).then([this] {
+                return make_ready_future<stop_iteration>(_stopped ? stop_iteration::yes : stop_iteration::no);
+            });
+        });
+    }
 public:
     echoserver(bool verbose = false)
             : _certs(make_shared<tls::server_credentials>(make_shared<tls::dh_params>()))
             , _verbose(verbose)
     {}
 
-    future<> listen(socket_address addr, sstring crtfile, sstring keyfile, tls::client_auth ca = tls::client_auth::NONE) {
-        _certs->set_client_auth(ca);
+    future<> listen(socket_address addr, sstring crtfile, sstring keyfile, sstring cafile) {
         _certs->set_dn_verification_callback([](seastar::tls::session_type, sstring subject, sstring issuer){
             std::cout << "DN Verification callback, subject: " << subject << " issuer: " << issuer << std::endl;
         });
-        return _certs->set_x509_key_file(crtfile, keyfile, tls::x509_crt_format::PEM).then([this, addr] {
-            ::listen_options opts;
-            opts.reuse_address = true;
+        auto f = make_ready_future();
+        auto cauth = tls::client_auth::NONE;
+        if (cafile != "") {
+            cauth = tls::client_auth::REQUIRE;
+            f = _certs->set_x509_trust_file(cafile, tls::x509_crt_format::PEM);
+        }
+        _certs->set_client_auth(cauth);
+        return f.then([this, addr, crtfile, keyfile] {
+            return _certs->set_x509_key_file(crtfile, keyfile, tls::x509_crt_format::PEM).then([this, addr] {
+                ::listen_options opts;
+                    opts.reuse_address = true;
 
-            _socket = tls::listen(_certs, addr, opts);
+                    _socket = tls::listen(_certs, addr, opts);
 
-            // Listen in background.
-            (void)repeat([this] {
-                if (_stopped) {
-                    return make_ready_future<stop_iteration>(stop_iteration::yes);
-                }
-                return with_gate(_gate, [this] {
-                    return _socket.accept().then([this](accept_result ar) {
-                        ::connected_socket s = std::move(ar.connection);
-                        socket_address a = std::move(ar.remote_address);
-                        if (_verbose) {
-                            std::cout << "Got connection from "<< a << std::endl;
-                        }
-                        auto strms = make_lw_shared<streams>(std::move(s));
-                        return repeat([strms, this]() {
-                            return strms->in.read().then([this, strms](temporary_buffer<char> buf) {
-                                if (buf.empty()) {
-                                    if (_verbose) {
-                                        std::cout << "EOM" << std::endl;
-                                    }
-                                    return make_ready_future<stop_iteration>(stop_iteration::yes);
-                                }
-                                sstring tmp(buf.begin(), buf.end());
-                                if (_verbose) {
-                                    std::cout << "Read " << tmp.size() << "B" << std::endl;
-                                }
-                                return strms->out.write(tmp).then([strms]() {
-                                    return strms->out.flush();
-                                }).then([] {
-                                    return make_ready_future<stop_iteration>(stop_iteration::no);
-                                });
-                            });
-                        }).then([strms]{
-                            return strms->out.close();
-                        }).handle_exception([](auto ep) {
-                            std::cout << "Exception: " << ep << std::endl;
-                        }).finally([this, strms]{
-                            if (_verbose) {
-                                std::cout << "Ending session" << std::endl;
-                            }
-                            return strms->in.close();
-                        });
-                    }).handle_exception([this](auto ep) {
-                        if (!_stopped) {
-                            std::cerr << "Error: " << ep << std::endl;
-                        }
-                    }).then([this] {
-                        return make_ready_future<stop_iteration>(_stopped ? stop_iteration::yes : stop_iteration::no);
+                    // Listen in background.
+                    (void)repeat([this] {
+                        return run_once();
                     });
-                });
+                    return make_ready_future();
             });
-            return make_ready_future();
         });
     }
 

--- a/demos/tls_echo_server_demo.cc
+++ b/demos/tls_echo_server_demo.cc
@@ -34,6 +34,7 @@ int main(int ac, char** av) {
     app.add_options()
                     ("port", bpo::value<uint16_t>()->default_value(10000), "Server port")
                     ("address", bpo::value<std::string>()->default_value("127.0.0.1"), "Server address")
+                    ("ca,a", bpo::value<std::string>()->default_value(""), "Server CA chain file")
                     ("cert,c", bpo::value<std::string>()->required(), "Server certificate file")
                     ("key,k", bpo::value<std::string>()->required(), "Certificate key")
                     ("verbose,v", bpo::value<bool>()->default_value(false)->implicit_value(true), "Verbose")
@@ -41,6 +42,7 @@ int main(int ac, char** av) {
     return app.run_deprecated(ac, av, [&] {
         auto&& config = app.configuration();
         uint16_t port = config["port"].as<uint16_t>();
+        auto ca = config["ca"].as<std::string>();
         auto crt = config["cert"].as<std::string>();
         auto key = config["key"].as<std::string>();
         auto addr = config["address"].as<std::string>();
@@ -52,7 +54,7 @@ int main(int ac, char** av) {
 
             auto server = ::make_shared<seastar::sharded<echoserver>>();
             return server->start(verbose).then([=]() {
-                return server->invoke_on_all(&echoserver::listen, socket_address(ia), sstring(crt), sstring(key), tls::client_auth::NONE);
+                return server->invoke_on_all(&echoserver::listen, socket_address(ia), sstring(crt), sstring(key), sstring(ca));
             }).handle_exception([=](auto e) {
                 std::cerr << "Error: " << e << std::endl;
                 engine().exit(1);

--- a/demos/tls_simple_client_demo.cc
+++ b/demos/tls_simple_client_demo.cc
@@ -38,6 +38,8 @@ int main(int ac, char** av) {
                     ("port", bpo::value<uint16_t>()->default_value(10000), "Remote port")
                     ("address", bpo::value<std::string>()->default_value("127.0.0.1"), "Remote address")
                     ("trust,t", bpo::value<std::string>(), "Trust store")
+                    ("certificate", bpo::value<std::string>(), "Certficiate")
+                    ("key,k", bpo::value<std::string>(), "Private Keyfile")
                     ("msg,m", bpo::value<std::string>(), "Message to send")
                     ("bytes,b", bpo::value<size_t>()->default_value(512), "Use random bytes of length as message")
                     ("iterations,i", bpo::value<size_t>()->default_value(1), "Repeat X times")
@@ -66,6 +68,15 @@ int main(int ac, char** av) {
         if (config.count("trust")) {
             f = certs->set_x509_trust_file(config["trust"].as<std::string>(), tls::x509_crt_format::PEM);
         }
+
+        if (config.count("certificate") && config.count("key")) {
+            f = f.then([certs,
+                        cert = config["certificate"].as<std::string>(),
+                        key = config["key"].as<std::string>()]{
+                return certs->set_x509_key_file(cert, key, tls::x509_crt_format::PEM);
+            });
+        }
+
 
         seastar::shared_ptr<sstring> msg;
 

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -284,7 +284,6 @@ public:
         if (!X509_verify(x509_cert.get(), pkey.get())) {
             throw ossl_error("Failed to verify cert/key pair");
         }
-        X509_STORE_add_cert(*this, x509_cert.get());
         _cert_and_key = certkey_pair{.cert = std::move(x509_cert), .key = std::move(pkey)};
     }
 

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -697,7 +697,7 @@ public:
         // for data and use a
         auto f = make_ready_future<>();
         auto avail = BIO_ctrl_pending(_in_bio);
-        if (avail == 0) {
+        if (avail == 0 && SSL_pending(_ssl.get()) == 0) {
             f = wait_for_input();
         }
         return f.then([this]() {

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -522,6 +522,9 @@ public:
         if (t == session_type::SERVER) {
             SSL_set_accept_state(_ssl.get());
         } else {
+            if (!_hostname.empty()) {
+                SSL_set_tlsext_host_name(_ssl.get(), _hostname.data());
+            }
             SSL_set_connect_state(_ssl.get());
         }
         // SSL_set_bio transfers ownership of the read and write bios to the SSL instance
@@ -619,51 +622,35 @@ public:
         return with_semaphore(_out_sem, 1, std::bind(&session::do_put, this, i, e)).finally([p = std::move(p)] {});
     }
 
-    future<> do_handshake() {
-        if (connected()) {
-            return make_ready_future<>();
+    template<typename session_func, typename want_read_func>
+    future<> do_handshake(session_func session_fn, want_read_func want_read_fn) {
+        auto n = session_fn(_ssl.get());
+        auto ssl_err = SSL_get_error(_ssl.get(), n);
+        switch (ssl_err) {
+        case SSL_ERROR_NONE:
+            break;
+        case SSL_ERROR_WANT_READ:
+            return want_read_fn();
+        case SSL_ERROR_WANT_WRITE:
+            return wait_for_input();
+        case SSL_ERROR_SSL:
+        {
+            // Catch-all for handshake errors
+            auto ec = ERR_GET_REASON(ERR_get_error());
+            switch (ec) {
+            case SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE:
+            case SSL_R_CERTIFICATE_VERIFY_FAILED:
+            case SSL_R_NO_CERTIFICATES_RETURNED:
+                verify(); // should throw
+                [[fallthrough]];
+            default:
+                return make_exception_future<>(ossl_error("Failed to establish SSL handshake"));
+            }
         }
-        if (_type == session_type::CLIENT && !_hostname.empty()) {
-            SSL_set_tlsext_host_name(_ssl.get(), _hostname.data());
+        default:
+            return make_exception_future<>(ossl_error("Unhandled error code observed"));
         }
-
-        return do_until(
-            [this]{ return connected() || eof(); },
-            [this]{
-                return wait_for_input().then([this]{
-                    auto n = SSL_accept(_ssl.get());
-                    auto ssl_err = SSL_get_error(_ssl.get(), n);
-                    switch (ssl_err) {
-                    case SSL_ERROR_NONE:
-                        break;
-                    case SSL_ERROR_WANT_READ:
-                        return pull_encrypted_and_send();
-                    case SSL_ERROR_WANT_WRITE:
-                        return wait_for_input();
-                    case SSL_ERROR_SSL:
-                    {
-                        // Catch-all for handshake errors
-                        auto ec = ERR_GET_REASON(ERR_get_error())
-                        switch (ec) {
-                        case SSL_R_PEER_DID_NOT_RETURN_A_CERTIFICATE:
-                        case SSL_R_CERTIFICATE_VERIFY_FAILED:
-                        case SSL_R_NO_CERTIFICATES_RETURNED:
-                            verify(); // should throw
-                            [[fallthrough]];
-                        default:
-                            return make_exception_future<>(ossl_error("Failed to establish SSL handshake"));
-                        }
-                    }
-                    default:
-                        return make_exception_future<>(ossl_error("Unhandled error code observed"));
-                    }
-                    return make_ready_future<>();
-                });
-            }).then([this]{
-                if (_type == session_type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
-                    verify();
-                }
-            });
+        return make_ready_future<>();
     }
 
     future<> wait_for_input() {
@@ -839,11 +826,26 @@ public:
             });
         });
     }
+
+
     future<> handshake() {
         // acquire both semaphores to sync both read & write
         return with_semaphore(_in_sem, 1, [this] {
             return with_semaphore(_out_sem, 1, [this] {
-                return do_handshake().handle_exception([this](auto ep) {
+                if (connected()) {
+                    return make_ready_future<>();
+                }
+                auto fn = (_type == session_type::SERVER) ?
+                        std::bind(&session::server_handshake, this) :
+                        std::bind(&session::client_handshake, this);
+                return do_until(
+                    [this]{ return connected(); },
+                    [fn = std::move(fn)]{ return fn(); }
+                ).then([this]{
+                    if (_type == session_type::CLIENT || _creds->get_client_auth() != client_auth::NONE) {
+                        verify();
+                    }
+                }).handle_exception([this](auto ep) {
                     if (!_error) {
                         _error = ep;
                     }
@@ -1097,6 +1099,28 @@ private:
             return ossl_str;
         }
         return std::nullopt;
+    }
+
+    future<> client_handshake() {
+        return do_handshake(SSL_connect, [this]{
+            return pull_encrypted_and_send().then([this]{
+                return wait_for_input().then([this]{
+                    if (eof()) {
+                        return make_exception_future<>(std::runtime_error("EOF observed during handshake"));
+                    }
+                    return make_ready_future<>();
+                });
+            });
+        });
+    }
+
+    future<> server_handshake() {
+        return wait_for_input().then([this]{
+            if (eof()) {
+                return make_exception_future<>(std::runtime_error("EOF observed during handshake"));
+            }
+            return do_handshake(SSL_accept, std::bind(&session::pull_encrypted_and_send, this));
+        });
     }
 
 private:

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -385,13 +385,18 @@ public:
         return _cert_and_key;
     }
 
-    future<> set_system_trust() {
-        return make_ready_future<>();
-    }
-
 private:
+    friend class certificate_credentials;
     friend class credentials_builder;
     friend class session;
+
+    void set_load_system_trust(bool trust) {
+        _load_system_trust = trust;
+    }
+
+    bool need_load_system_trust() const {
+        return _load_system_trust;
+    }
 
     x509_ptr _last_cert;
     x509_store_ptr _creds;
@@ -399,6 +404,7 @@ private:
     certkey_pair _cert_and_key;
     std::shared_ptr<tls::dh_params::impl> _dh_params;
     client_auth _client_auth = client_auth::NONE;
+    bool _load_system_trust = false;
     dn_callback _dn_callback;
     sstring _priority;
 };
@@ -436,7 +442,8 @@ void tls::certificate_credentials::set_simple_pkcs12(const blob& b,
 }
 
 future<> tls::certificate_credentials::set_system_trust() {
-    return _impl->set_system_trust();
+    _impl->_load_system_trust = true;
+    return make_ready_future<>();
 }
 
 void tls::certificate_credentials::set_priority_string(const sstring& prio) {
@@ -473,7 +480,9 @@ std::optional<std::vector<cert_info>> tls::certificate_credentials::get_trust_li
     }
 }
 
-void tls::certificate_credentials::enable_load_system_trust() {}
+void tls::certificate_credentials::enable_load_system_trust() {
+    _impl->_load_system_trust = true;
+}
 
 void tls::certificate_credentials::set_client_auth(client_auth ca) {
     _impl->set_client_auth(ca);
@@ -858,6 +867,13 @@ public:
 
 
     future<> handshake() {
+        if (_creds->need_load_system_trust()) {
+            if (!SSL_CTX_set_default_verify_paths(_ctx.get())) {
+                throw ossl_error("Couldn't load system trust");
+            }
+            _creds->set_load_system_trust(false);
+        }
+
         // acquire both semaphores to sync both read & write
         return with_semaphore(_in_sem, 1, [this] {
             return with_semaphore(_out_sem, 1, [this] {

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -587,8 +587,14 @@ public:
                 auto bytes_written = SSL_write(_ssl.get(), ptr + off, size - off);
                 if(bytes_written <= 0){
                     const auto ec = SSL_get_error(_ssl.get(), bytes_written);
-                    if (ec == SSL_ERROR_WANT_READ || ec == SSL_ERROR_WANT_WRITE) {
-                        /// TODO(rob) handle this condition
+                    if (ec == SSL_ERROR_WANT_WRITE) {
+                        return pull_encrypted_and_send().then([]{
+                            return stop_iteration::no;
+                        });
+                    } else if (ec == SSL_ERROR_WANT_READ) {
+                        return do_get().then([](auto){
+                            return stop_iteration::no;
+                        });
                     }
                     _error = std::make_exception_ptr(ossl_error("Failed on call to SSL_write"));
                     return make_exception_future<stop_iteration>(_error);
@@ -718,6 +724,10 @@ public:
                     // Not enough data resides in the internal SSL buffers to merit a read, i.e.
                     // maybe a record doesn't exist in its entirety, therefore read more from input.
                     return do_get();
+                } else if (ec == SSL_ERROR_WANT_WRITE) {
+                    // In the case TLS renegotiation needs to be performed and the buffers are full
+                    // SSL_read returns this error code
+                    return pull_encrypted_and_send().then([this]{ return do_get(); });
                 }
                 _error = std::make_exception_ptr(ossl_error(fmt::format("Error upon call to SSL_read: {}", ec)));
                 return make_exception_future<buf_type>(_error);

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -281,9 +281,11 @@ public:
         if (!pkey) {
             throw ossl_error("Error attempting to parse private key");
         }
+#if 0 // https://github.com/redpanda-data/core-internal/issues/1233
         if (!X509_verify(x509_cert.get(), pkey.get())) {
             throw ossl_error("Failed to verify cert/key pair");
         }
+#endif
         _cert_and_key = certkey_pair{.cert = std::move(x509_cert), .key = std::move(pkey)};
     }
 
@@ -298,12 +300,14 @@ public:
             if (!PKCS12_parse(p12.get(), password.c_str(), &pkey, &cert, &ca)) {
                 throw ossl_error("Failed to extract cert key pair from pkcs12 file");
             }
+#if 0 // https://github.com/redpanda-data/core-internal/issues/1233
             // Ensure signature validation checks pass before continuing
             if (!X509_verify(cert, pkey)) {
                 X509_free(cert);
                 EVP_PKEY_free(pkey);
                 throw ossl_error("Failed to verify cert/key pair");
             }
+#endif
             _cert_and_key = certkey_pair{.cert = x509_ptr(cert), .key = evp_pkey_ptr(pkey)};
 
             // Iterate through all elements in the certificate chain, adding them to the store

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1065,7 +1065,11 @@ private:
             throw ossl_error("Failed to initialize SSL context");
         }
 
+        const auto& ck_pair = _creds->get_certkey_pair();
         if (_type == session_type::SERVER) {
+            if (!ck_pair) {
+                throw ossl_error("Cannot start session without cert/key pair for server");
+            }
             switch(_creds->get_client_auth()) {
                 case client_auth::NONE:
                 default:
@@ -1078,11 +1082,10 @@ private:
                     SSL_CTX_set_verify(_ctx.get(), SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
                     break;
             }
+        }
 
-            auto& ck_pair = _creds->get_certkey_pair();
-            if (ck_pair.key == nullptr || ck_pair.cert == nullptr) {
-                throw ossl_error("Cannot start session without cert/key pair for server");
-            }
+        // Servers must supply both certificate and key, clients may optionally use these
+        if (ck_pair) {
             if (!SSL_CTX_use_cert_and_key(ssl_ctx.get(), ck_pair.cert.get(), ck_pair.key.get(), nullptr, 1)) {
                 throw ossl_error("Failed to load cert/key pair");
             }

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -362,11 +362,15 @@ public:
         return _client_auth;
     }
 
-    void set_priority_string(const sstring&) {}
+    void set_priority_string(const sstring& priority) {
+        _priority = priority;
+    }
 
     void set_dn_verification_callback(dn_callback cb) {
         _dn_callback = std::move(cb);
     }
+
+    const sstring& get_priority_string() const { return _priority; }
 
     // Returns the certificate of last attempted verification attempt, if there was no attempt,
     // this will not be updated and will remain stale
@@ -393,6 +397,7 @@ private:
     std::shared_ptr<tls::dh_params::impl> _dh_params;
     client_auth _client_auth = client_auth::NONE;
     dn_callback _dn_callback;
+    sstring _priority;
 };
 
 tls::certificate_credentials::certificate_credentials()
@@ -1093,6 +1098,12 @@ private:
         // Increments the reference count of *_creds, now should have a total ref count of two, will be deallocated
         // when both OpenSSL and the certificate_manager call X509_STORE_free
         SSL_CTX_set1_cert_store(_ctx.get(), *_creds);
+
+        if (_creds->get_priority_string() != "") {
+            if (SSL_CTX_set_cipher_list(_ctx.get(), _creds->get_priority_string().c_str()) != 1) {
+                throw ossl_error("Failed to set priority list");
+            }
+        }
         return ssl_ctx;
     }
 

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -388,7 +388,6 @@ public:
                         .serial = extract_x509_serial(cert),
                         .expiry = extract_x509_expiry(cert)});
             }
-            num_elements -= 1;
         }
         return cert_infos;
     }

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -559,7 +559,8 @@ public:
                     buf.trim(n);
                     msg->append(std::move(buf));
                 } else if (!BIO_should_retry(_out_bio)) {
-                    return make_exception_future<>(ossl_error("Failed to read data from the BIO"));
+                    _error = std::make_exception_ptr(ossl_error("Failed to read data from the BIO"));
+                    return make_exception_future<>(_error);
                 }
                 return make_ready_future<>();
         }).then([this, msg](){
@@ -590,7 +591,8 @@ public:
                     if (ec == SSL_ERROR_WANT_READ || ec == SSL_ERROR_WANT_WRITE) {
                         /// TODO(rob) handle this condition
                     }
-                    return make_exception_future<stop_iteration>(ossl_error("Failed on call to SSL_write"));
+                    _error = std::make_exception_ptr(ossl_error("Failed on call to SSL_write"));
+                    return make_exception_future<stop_iteration>(_error);
                 }
                 off += bytes_written;
                 /// Regardless of error, continue to send fragments
@@ -652,11 +654,13 @@ public:
                 verify(); // should throw
                 [[fallthrough]];
             default:
-                return make_exception_future<>(ossl_error("Failed to establish SSL handshake"));
+                _error = std::make_exception_ptr(ossl_error("Failed to establish SSL handshake"));
+                return make_exception_future<>(_error);
             }
         }
         default:
-            return make_exception_future<>(ossl_error("Unhandled error code observed"));
+            _error = std::make_exception_ptr(ossl_error("Unhandled error code observed"));
+            return make_exception_future<>(_error);
         }
         return make_ready_future<>();
     }
@@ -679,13 +683,12 @@ public:
               [this, buf]{
                   const auto n = BIO_write(_in_bio, buf->get(), buf->size());
                   if (n <= 0) {
-                      return make_exception_future<>(ossl_error("Error while waiting for input"));
+                      _error = std::make_exception_ptr(ossl_error("Error while waiting for input"));
+                      return make_exception_future<>(_error);
                   }
                   buf->trim_front(n);
                   return make_ready_future();
               }).finally([buf]{});
-        }).handle_exception([](auto ep){
-            return make_exception_future(ep);
         });
     }
 
@@ -714,7 +717,8 @@ public:
                     close();
                     return make_ready_future<buf_type>(buf_type());
                 }
-                return make_exception_future<buf_type>(ossl_error("Error upon call to SSL_read"));
+                _error = std::make_exception_ptr(ossl_error("Error upon call to SSL_read"));
+                return make_exception_future<buf_type>(_error);
             }
             buf.trim(bytes_read);
             return make_ready_future<buf_type>(std::move(buf));
@@ -769,7 +773,8 @@ public:
         }
 
         // Fatal error
-        return make_exception_future<>(ossl_error("fatal error during ssl shutdown"));
+        _error = std::make_exception_ptr(ossl_error("fatal error during ssl shutdown"));
+        return make_exception_future<>(_error);
     }
 
     void verify() {

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -711,13 +711,17 @@ public:
             auto bytes_read = SSL_read(_ssl.get(), buf.get_write(), buf_size);
             if (bytes_read <= 0) {
                 const auto ec = SSL_get_error(_ssl.get(), bytes_read);
-                if (ec == SSL_ERROR_ZERO_RETURN && connected()) {
+                if (ec == SSL_ERROR_ZERO_RETURN) {
                     // Client has initiated shutdown by sending EOF
                     _eof = true;
                     close();
                     return make_ready_future<buf_type>(buf_type());
+                } else if (ec == SSL_ERROR_WANT_READ) {
+                    // Not enough data resides in the internal SSL buffers to merit a read, i.e.
+                    // maybe a record doesn't exist in its entirety, therefore read more from input.
+                    return do_get();
                 }
-                _error = std::make_exception_ptr(ossl_error("Error upon call to SSL_read"));
+                _error = std::make_exception_ptr(ossl_error(fmt::format("Error upon call to SSL_read: {}", ec)));
                 return make_exception_future<buf_type>(_error);
             }
             buf.trim(bytes_read);

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1078,13 +1078,13 @@ private:
             switch(_creds->get_client_auth()) {
                 case client_auth::NONE:
                 default:
-                    SSL_CTX_set_verify(_ctx.get(), SSL_VERIFY_NONE, nullptr);
+                    SSL_CTX_set_verify(ssl_ctx.get(), SSL_VERIFY_NONE, nullptr);
                     break;
                 case client_auth::REQUEST:
-                    SSL_CTX_set_verify(_ctx.get(), SSL_VERIFY_PEER, nullptr);
+                    SSL_CTX_set_verify(ssl_ctx.get(), SSL_VERIFY_PEER, nullptr);
                     break;
                 case client_auth::REQUIRE:
-                    SSL_CTX_set_verify(_ctx.get(), SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+                    SSL_CTX_set_verify(ssl_ctx.get(), SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
                     break;
             }
         }
@@ -1097,10 +1097,10 @@ private:
         }
         // Increments the reference count of *_creds, now should have a total ref count of two, will be deallocated
         // when both OpenSSL and the certificate_manager call X509_STORE_free
-        SSL_CTX_set1_cert_store(_ctx.get(), *_creds);
+        SSL_CTX_set1_cert_store(ssl_ctx.get(), *_creds);
 
         if (_creds->get_priority_string() != "") {
-            if (SSL_CTX_set_cipher_list(_ctx.get(), _creds->get_priority_string().c_str()) != 1) {
+            if (SSL_CTX_set_cipher_list(ssl_ctx.get(), _creds->get_priority_string().c_str()) != 1) {
                 throw ossl_error("Failed to set priority list");
             }
         }

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -277,7 +277,7 @@ shared_ptr<tls::certificate_credentials> tls::credentials_builder::build_certifi
 shared_ptr<tls::server_credentials> tls::credentials_builder::build_server_credentials() const {
     auto i = _blobs.find(dh_level_key);
     if (i == _blobs.end()) {
-#if GNUTLS_VERSION_NUMBER < 0x030600
+#if GNUTLS_VERSION_NUMBER < 0x030600 && !SEASTAR_WITH_TLS_OSSL
         throw std::invalid_argument("No DH level set");
 #else
         auto creds = make_shared<server_credentials>();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -644,7 +644,7 @@ function(seastar_gen_mtls_certs)
   seastar_sign_cert("mtls_server"
     CA ${cert_ca}
     SERIAL_NUM 1
-    COMMON_NAME "redpanda.com")
+    COMMON_NAME "server.org")
   # client1 certificates
   seastar_sign_cert("mtls_client1"
     CA ${cert_ca}

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -161,6 +161,16 @@ SEASTAR_TEST_CASE(test_x509_client_with_builder_system_trust_multiple) {
 }
 
 SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings) {
+#ifdef SEASTAR_WITH_TLS_OSSL
+    static std::vector<sstring> prios( {
+        "PSK-CHACHA20-POLY1305",
+        "DHE-PSK-AES128-GCM-SHA256",
+        "ECDHE-RSA-AES128-GCM-SHA256",
+        "RSA-PSK-AES128-CBC-SHA",
+        "ECDHE-ECDSA-AES256-GCM-SHA384",
+        "AES128-GCM-SHA256"
+    });
+#else
     static std::vector<sstring> prios( {
         "NORMAL:+ARCFOUR-128", // means normal ciphers plus ARCFOUR-128.
         "SECURE128:-VERS-SSL3.0:+COMP-DEFLATE", // means that only secure ciphers are enabled, SSL3.0 is disabled, and libz compression enabled.
@@ -172,6 +182,7 @@ SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings) {
         "SECURE128:-VERS-TLS1.0:+COMP-DEFLATE",
         "SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.2"
     });
+#endif
     return do_for_each(prios, [](const sstring & prio) {
         tls::credentials_builder b;
         (void)b.set_system_trust();
@@ -181,9 +192,15 @@ SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings) {
 }
 
 SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings_fail) {
+#ifdef SEASTAR_WITH_TLS_OSSL
+    static std::vector<sstring> prios( {
+        "RSA-MD5-AES256-CBC-SHA"
+    });
+#else
     static std::vector<sstring> prios( { "NONE",
         "NONE:+CURVE-SECP256R1"
     });
+#endif
     return do_for_each(prios, [](const sstring & prio) {
         tls::credentials_builder b;
         (void)b.set_system_trust();
@@ -298,6 +315,16 @@ SEASTAR_THREAD_TEST_CASE(test_x509_client_with_builder_multiple) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings) {
+#ifdef SEASTAR_WITH_TLS_OSSL
+    static std::vector<sstring> prios( {
+        "PSK-CHACHA20-POLY1305",
+        "DHE-PSK-AES128-GCM-SHA256",
+        "ECDHE-RSA-AES128-GCM-SHA256",
+        "RSA-PSK-AES128-CBC-SHA",
+        "ECDHE-ECDSA-AES256-GCM-SHA384",
+        "AES128-GCM-SHA256"
+    });
+#else
     static std::vector<sstring> prios( {
         "NORMAL:+ARCFOUR-128", // means normal ciphers plus ARCFOUR-128.
         "SECURE128:-VERS-SSL3.0:+COMP-DEFLATE", // means that only secure ciphers are enabled, SSL3.0 is disabled, and libz compression enabled.
@@ -309,6 +336,7 @@ SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings) {
         "SECURE128:-VERS-TLS1.0:+COMP-DEFLATE",
         "SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.2"
     });
+#endif
     tls::credentials_builder b;
     https_server server;
     b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
@@ -320,9 +348,15 @@ SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings_fail) {
+#ifdef SEASTAR_WITH_TLS_OSSL
+    static std::vector<sstring> prios( {
+        "RSA-MD5-AES256-CBC-SHA"
+    });
+#else
     static std::vector<sstring> prios( { "NONE",
         "NONE:+CURVE-SECP256R1"
     });
+#endif
     tls::credentials_builder b;
     https_server server;
     b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -654,7 +654,7 @@ SEASTAR_TEST_CASE(test_simple_x509_client_server_again) {
     return run_echo_test(message, 20, certfile("catest.pem"), "test.scylladb.org");
 }
 
-#if GNUTLS_VERSION_NUMBER >= 0x030600
+#if GNUTLS_VERSION_NUMBER >= 0x030600 || SEASTAR_WITH_TLS_OSSL
 // Test #769 - do not set dh_params in server certs - let gnutls negotiate.
 SEASTAR_TEST_CASE(test_simple_server_default_dhparams) {
     return run_echo_test(message, 20, certfile("catest.pem"), "test.scylladb.org",


### PR DESCRIPTION
This pull request adds support for clients, meaning calls to `tls::connect` will return a client that is able to communicate over mTLS with a server. Due to this , the seastar unit tests (`test_tls.cc`) can now be run, as they start the homegrown client and server and use them to communicate with eachother.

Other additional fixes include:
- Enable use of cipher priority strings
- Ensuring any exceptions will permanently fault the connection (akin to logic in the GnuTLS impl)
- Fixing a bug with SSL shutdown
- Fixing a bug with sending/receiving data that only was observed with large payloads
- Handling the SSL_WANT_READ/WRITE error codes in all edge cases
- Fixing the tls client/server demo programs to establish mTLS connections 