### PR TITLE
Avoid large alloc in prometheus metrics with `unordered_dense`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,6 +798,7 @@ target_link_libraries (seastar
     lksctp-tools::lksctp-tools
     rt::rt
     yaml-cpp::yaml-cpp
+    unordered_dense::unordered_dense
     "$<BUILD_INTERFACE:Valgrind::valgrind>"
     Threads::Threads)
 

--- a/cmake/SeastarDependencies.cmake
+++ b/cmake/SeastarDependencies.cmake
@@ -103,7 +103,8 @@ macro (seastar_find_dependencies)
     lksctp-tools # No version information published.
     numactl # No version information published.
     rt
-    yaml-cpp)
+    yaml-cpp
+    unordered_dense)
 
   # Arguments to `find_package` for each 3rd-party dependency.
   # Note that the version specification is a "minimal" version requirement.
@@ -143,6 +144,8 @@ macro (seastar_find_dependencies)
     OPTION ${Seastar_NUMA})
   seastar_set_dep_args (yaml-cpp REQUIRED
     VERSION 0.5.1)
+  seastar_set_dep_args (unordered_dense
+    VERSION 4.4.0 CONFIG REQUIRED)
 
   foreach (third_party ${_seastar_all_dependencies})
     if (NOT _seastar_dep_skip_${third_party})

--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -33,6 +33,8 @@
 #include <seastar/core/loop.hh>
 #include <regex>
 
+#include <ankerl/unordered_dense.h>
+
 namespace seastar {
 
 extern seastar::logger seastar_logger;
@@ -531,7 +533,7 @@ void write_summary(std::stringstream& s, const config& ctx, const sstring& name,
  */
 class metric_aggregate_by_labels {
     std::vector<std::string> _labels_to_aggregate_by;
-    std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value> _values;
+    ankerl::unordered_dense::segmented_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value> _values;
 public:
     metric_aggregate_by_labels(std::vector<std::string> labels) : _labels_to_aggregate_by(std::move(labels)) {
     }
@@ -548,14 +550,14 @@ public:
         for (auto&& l : _labels_to_aggregate_by) {
             labels.erase(l);
         }
-        std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value>::iterator i = _values.find(labels);
+        auto i = _values.find(labels);
         if ( i == _values.end()) {
             _values.emplace(std::move(labels), m);
         } else {
             i->second += m;
         }
     }
-    const std::unordered_map<std::map<sstring, sstring>, seastar::metrics::impl::metric_value>& get_values() const noexcept {
+    const auto& get_values() const noexcept {
         return _values;
     }
     bool empty() const noexcept {


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/16949