### PR TITLE
Add label to io_threaded_fallbacks to categorize operations

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -270,7 +270,7 @@ void aio_storage_context::schedule_retry() {
         return _r._thread_pool->submit<syscall_result<int>>([this] () mutable {
             auto r = io_submit(_io_context, _aio_retries.size(), _aio_retries.data());
             return wrap_syscall<int>(r);
-        }).then_wrapped([this] (future<syscall_result<int>> f) {
+        }, submit_reason::aio_fallback).then_wrapped([this] (future<syscall_result<int>> f) {
             // If submit failed, just log the error and exit the loop.
             // The next call to submit_work will call schedule_retry again.
             if (f.failed()) {

--- a/src/core/thread_pool.hh
+++ b/src/core/thread_pool.hh
@@ -27,9 +27,36 @@ namespace seastar {
 
 class reactor;
 
+// Reasons for why a function had to be submitted to the thread_pool 
+enum class submit_reason : size_t {
+    // Used for aio operations what would block in `io_submit`.
+    aio_fallback,
+    // Used for file operations that don't have non-blocking alternatives.
+    file_operation,
+    // Used for process operations that don't have non-blocking alternatives.
+    process_operation,
+    // Used by default when a caller doesn't specify a submission reason.
+    unknown,
+};
+
+class submit_metrics {
+    uint64_t _counters[static_cast<size_t>(submit_reason::unknown) + 1]{};
+
+public:
+    void record_reason(submit_reason reason) {
+        reason = std::min(reason, submit_reason::unknown);
+        ++_counters[static_cast<size_t>(reason)];
+    }
+
+    uint64_t count_for(submit_reason reason) const {
+        reason = std::min(reason, submit_reason::unknown);
+        return _counters[static_cast<size_t>(reason)];
+    }
+};
+
 class thread_pool {
     reactor& _reactor;
-    uint64_t _aio_threaded_fallbacks = 0;
+    submit_metrics metrics;
     syscall_work_queue inter_thread_wq;
     posix_thread _worker_thread;
     std::atomic<bool> _stopped = { false };
@@ -38,11 +65,11 @@ public:
     explicit thread_pool(reactor& r, sstring thread_name);
     ~thread_pool();
     template <typename T, typename Func>
-    future<T> submit(Func func) noexcept {
-        ++_aio_threaded_fallbacks;
+    future<T> submit(Func func, submit_reason reason = submit_reason::unknown) noexcept {
+        metrics.record_reason(reason);
         return inter_thread_wq.submit<T>(std::move(func));
     }
-    uint64_t operation_count() const { return _aio_threaded_fallbacks; }
+    uint64_t count(submit_reason r) const { return metrics.count_for(r); }
 
     unsigned complete() { return inter_thread_wq.complete(); }
     // Before we enter interrupt mode, we must make sure that the syscall thread will properly


### PR DESCRIPTION
The main purpose of this PR is to allow us to know how many of the operations submitted to the thread pool are from failed aio reads/writes.