### PR TITLE
Backport PR #107 new `to_reply()` method from http exception

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -80,10 +80,22 @@ private:
  */
 class redirect_exception : public base_exception {
 public:
-    redirect_exception(const std::string& url, http::reply::status_type status = http::reply::status_type::moved_permanently)
-            : base_exception("", status), url(url) {
+    redirect_exception(const std::string& url, http::reply::status_type status = http::reply::status_type::moved_permanently, const std::optional<int>& retry_after = std::nullopt)
+            : base_exception("", status), url(url), retry_after(retry_after) {
     }
+
+    http::reply to_reply() const {
+        http::reply reply{};
+        reply.add_header("Location", url);
+        if (retry_after.has_value()) {
+            reply.add_header("Retry-After", std::to_string(retry_after.value()));
+        }
+        reply.set_status(status());
+        return reply;
+    }
+
     std::string url;
+    std::optional<int> retry_after;
 };
 
 /**

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -73,8 +73,7 @@ std::unique_ptr<http::reply> routes::exception_reply(std::exception_ptr eptr) {
         }
         std::rethrow_exception(eptr);
     } catch (const redirect_exception& _e) {
-       rep.reset(new http::reply());
-       rep->add_header("Location", _e.url).set_status(_e.status());
+       *rep = _e.to_reply();
     } catch (const base_exception& e) {
         if (e.content_type().size()) {
             rep->set_status(e.status(), e.str());
@@ -99,6 +98,9 @@ future<std::unique_ptr<http::reply> > routes::handle(const sstring& path, std::u
             handler->verify_mandatory_params(*req);
             auto r =  handler->handle(path, std::move(req), std::move(rep));
             return r.handle_exception(_general_handler);
+        } catch (const redirect_exception& _e) {
+            *rep = _e.to_reply();
+            rep->done("json");
         } catch (...) {
             rep = exception_reply(std::current_exception());
         }


### PR DESCRIPTION
Backport of PR: https://github.com/redpanda-data/seastar/pull/107

This PR made its way into 24.1.x , backporting to v24.2.x