### PR TITLE
Temporarily replace call to formatter<string_view>

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -523,7 +523,7 @@ namespace tls {
 template <> struct fmt::formatter<seastar::tls::subject_alt_name_type> : fmt::formatter<std::string_view> {
     template <typename FormatContext>
     auto format(seastar::tls::subject_alt_name_type type, FormatContext& ctx) const {
-        return formatter<std::string_view>::format(format_as(type), ctx);
+        return fmt::format_to(ctx.out(), "{}", format_as(type));
     }
 };
 


### PR DESCRIPTION
- Redpanda is failing to compile due to formatter<string_view>::format being SFINAE'd away.

- As a temporary fix, replacing call to ::format with ::format_to to resolve the compilation error