### PR TITLE
net/tls: Replace cert_info::bytes with vector<byte>

### DIFF
--- a/include/seastar/net/api.hh
+++ b/include/seastar/net/api.hh
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <memory>
 #include <vector>
+#include <cstddef>
 #include <cstring>
 #include <sys/types.h>
 #endif
@@ -178,9 +179,7 @@ struct session_dn {
 
   /// Information about a certificate
 struct cert_info {
-    static constexpr size_t bytes_inline_size = 31;
-    using bytes = basic_sstring<uint8_t, uint32_t, bytes_inline_size, false>;
-    bytes serial;
+    std::vector<std::byte> serial;
     time_t expiry;
 };
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -175,10 +175,10 @@ static void gtls_chk(int res) {
     }
 }
 
-static cert_info::bytes extract_x509_serial(gnutls_x509_crt_t cert) {
+static std::vector<std::byte> extract_x509_serial(gnutls_x509_crt_t cert) {
     constexpr size_t serial_max = 128;
     size_t serial_size{serial_max};
-    cert_info::bytes serial(cert_info::bytes::initialized_later{}, serial_size);
+    std::vector<std::byte> serial(serial_size);
     gtls_chk(gnutls_x509_crt_get_serial(cert, serial.data(), &serial_size));
     serial.resize(serial_size);
     return serial;


### PR DESCRIPTION
char_traits<unsigned> is deprecated in LLVM 18, slated for removal in LLVM 19. Therefore remove this non-standard usage from cert_info.

Extracting the x509 serial number is a relatively infrequent operation and the result is always <= 20B, so the cost of using a vector here should be marginal.