### PR TITLE
[CORE-2426] tls: Added new functions to support OpenSSL

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -114,6 +114,15 @@ namespace tls {
         shared_ptr<impl> _impl;
     };
 
+    enum class tls_version {
+        tlsv1_0,
+        tlsv1_1,
+        tlsv1_2,
+        tlsv1_3
+    };
+
+    std::ostream& operator<<(std::ostream&, const tls_version&);
+
     class abstract_credentials {
     protected:
         abstract_credentials() = default;
@@ -193,13 +202,54 @@ namespace tls {
 
         // TODO add methods for certificate verification
 
+#ifndef SEASTAR_WITH_TLS_OSSL
         /**
          * TLS handshake priority string. See gnutls docs and syntax at
          * https://gnutls.org/manual/html_node/Priority-Strings.html
          *
          * Allows specifying order and allowance for handshake alg.
+         *
          */
         void set_priority_string(const sstring&);
+#endif
+
+#ifdef SEASTAR_WITH_TLS_OSSL
+        /**
+         * Used to set the cipher string for TLS versions 1.2 and below
+         *
+         * See https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_cipher_list.html
+         * for documentation on the format of the cipher list string
+         */
+        void set_cipher_string(const sstring&);
+
+        /**
+         * Used to set the cipher suites to use for TLSv1.3
+         *
+         * See https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_ciphersuites.html
+         * for documentation on the format of the ciphersuites string.
+         */
+        void set_ciphersuites(const sstring&);
+
+        /**
+         * Call this when you want to enable server precedence when
+         * negotitating the TLS handshake.  Client precedence is on
+         * by default.
+         */
+        void enable_server_precedence();
+        /**
+         * @brief Set the minimum tls version for this connection
+         *
+         * If unset, will default to the minimum of the underlying
+         * implementation
+         */
+        void set_minimum_tls_version(tls_version);
+        /**
+         * @brief Set the maximum tls version for this connection
+         *
+         * If unset, will default to the maximum of the underly implementation
+         */
+        void set_maximum_tls_version(tls_version);
+#endif
 
         /**
          * Register a callback for receiving Distinguished Name (DN) information
@@ -312,7 +362,17 @@ namespace tls {
 
         future<> set_system_trust();
         void set_client_auth(client_auth);
+#ifndef SEASTAR_WITH_TLS_OSSL
         void set_priority_string(const sstring&);
+#endif
+
+#ifdef SEASTAR_WITH_TLS_OSSL
+        void set_cipher_string(const sstring&);
+        void set_ciphersuites(const sstring&);
+        void enable_server_precedence();
+        void set_minimum_tls_version(tls_version);
+        void set_maximum_tls_version(tls_version);
+#endif
 
         void apply_to(certificate_credentials&) const;
 
@@ -333,6 +393,11 @@ namespace tls {
         std::multimap<sstring, boost::any> _blobs;
         client_auth _client_auth = client_auth::NONE;
         sstring _priority;
+        sstring _cipher_string;
+        sstring _ciphersuites;
+        bool _enable_server_precedence = false;
+        std::optional<tls_version> _min_tls_version;
+        std::optional<tls_version> _max_tls_version;
     };
 
     /// TLS configuration options

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -84,6 +84,21 @@ struct fmt::formatter<seastar::ossl_errc> : public fmt::formatter<std::string_vi
 
 namespace seastar {
 
+int tls_version_to_ossl(tls::tls_version version) {
+    switch(version) {
+    case tls::tls_version::tlsv1_0:
+        return TLS1_VERSION;
+    case tls::tls_version::tlsv1_1:
+        return TLS1_1_VERSION;
+    case tls::tls_version::tlsv1_2:
+        return TLS1_2_VERSION;
+    case tls::tls_version::tlsv1_3:
+        return TLS1_3_VERSION;
+    }
+
+    __builtin_unreachable();
+}
+
 class ossl_error_category : public std::error_category {
 public:
     constexpr ossl_error_category() noexcept : std::error_category{} {}
@@ -453,15 +468,49 @@ public:
         return _client_auth;
     }
 
-    void set_priority_string(const sstring& priority) {
-        _priority = priority;
-    }
-
     void set_dn_verification_callback(dn_callback cb) {
         _dn_callback = std::move(cb);
     }
 
-    const sstring& get_priority_string() const { return _priority; }
+    void set_cipher_string(const sstring& cipher_string) {
+        _cipher_string = cipher_string;
+    }
+
+    void set_ciphersuites(const sstring& ciphersuites) {
+        _ciphersuites = ciphersuites;
+    }
+
+    void enable_server_precedence() {
+        _enable_server_precedence = true;
+    }
+
+    void set_minimum_tls_version(tls_version version) {
+        _min_tls_version.emplace(version);
+    }
+
+    void set_maximum_tls_version(tls_version version) {
+        _max_tls_version.emplace(version);
+    }
+
+    const sstring& get_cipher_string() const noexcept {
+        return _cipher_string;
+    }
+
+    const sstring& get_ciphersuites() const noexcept {
+        return _ciphersuites;
+    }
+
+    bool is_server_precedence_enabled() {
+        return _enable_server_precedence;
+    }
+
+    const std::optional<tls_version>& minimum_tls_version() const noexcept {
+        return _min_tls_version;
+    }
+
+    const std::optional<tls_version>& maximum_tls_version() const noexcept {
+        return _max_tls_version;
+    }
 
     // Returns the certificate of last attempted verification attempt, if there was no attempt,
     // this will not be updated and will remain stale
@@ -494,7 +543,11 @@ private:
     client_auth _client_auth = client_auth::NONE;
     bool _load_system_trust = false;
     dn_callback _dn_callback;
-    sstring _priority;
+    sstring _cipher_string;
+    sstring _ciphersuites;
+    bool _enable_server_precedence = false;
+    std::optional<tls_version> _min_tls_version;
+    std::optional<tls_version> _max_tls_version;
 };
 
 tls::certificate_credentials::certificate_credentials()
@@ -534,8 +587,24 @@ future<> tls::certificate_credentials::set_system_trust() {
     return make_ready_future<>();
 }
 
-void tls::certificate_credentials::set_priority_string(const sstring& prio) {
-    _impl->set_priority_string(prio);
+void tls::certificate_credentials::set_cipher_string(const sstring& cipher_string) {
+    _impl->set_cipher_string(cipher_string);
+}
+
+void tls::certificate_credentials::set_ciphersuites(const sstring& ciphersuites) {
+    _impl->set_ciphersuites(ciphersuites);
+}
+
+void tls::certificate_credentials::enable_server_precedence() {
+    _impl->enable_server_precedence();
+}
+
+void tls::certificate_credentials::set_minimum_tls_version(tls_version version) {
+    _impl->set_minimum_tls_version(version);
+}
+
+void tls::certificate_credentials::set_maximum_tls_version(tls_version version) {
+    _impl->set_maximum_tls_version(version);
 }
 
 void tls::certificate_credentials::set_dn_verification_callback(dn_callback cb) {
@@ -1451,9 +1520,42 @@ private:
                 break;
             }
 
-            SSL_CTX_set_options(
-              ssl_ctx.get(), SSL_OP_ALL | SSL_OP_ALLOW_CLIENT_RENEGOTIATION);
+            auto options = SSL_OP_ALL | SSL_OP_ALLOW_CLIENT_RENEGOTIATION;
+            if (_creds->is_server_precedence_enabled()) {
+                options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+            }
+
+            SSL_CTX_set_options(ssl_ctx.get(), options);
+        } else {
+            if (_creds->is_server_precedence_enabled()) {
+                SSL_CTX_set_options(ssl_ctx.get(), SSL_OP_CIPHER_SERVER_PREFERENCE);
+            }
         }
+
+        auto & min_tls_version = _creds->minimum_tls_version();
+        auto & max_tls_version = _creds->maximum_tls_version();
+
+        if (min_tls_version.has_value()) {
+            if (!SSL_CTX_set_min_proto_version(ssl_ctx.get(),
+                tls_version_to_ossl(*min_tls_version))) {
+                throw ossl_error::make_ossl_error(
+                    fmt::format("Failed to set minimum TLS version to {}",
+                        *min_tls_version));
+            }
+        }
+
+        if (max_tls_version.has_value()) {
+            if (!SSL_CTX_set_max_proto_version(ssl_ctx.get(),
+                tls_version_to_ossl(*max_tls_version))) {
+                    throw ossl_error::make_ossl_error(
+                        fmt::format("Failed to set maximum TLS version to {}",
+                            *max_tls_version));
+            }
+        }
+
+        // This call is required to lower SSL's security level to permit TLSv1.0 and TLSv1.1
+        // See https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_security_level.html
+        SSL_CTX_set_security_level(ssl_ctx.get(), 0);
 
         // Servers must supply both certificate and key, clients may
         // optionally use these
@@ -1473,12 +1575,23 @@ private:
         // the certificate_manager call X509_STORE_free
         SSL_CTX_set1_cert_store(ssl_ctx.get(), *_creds);
 
-        if (_creds->get_priority_string() != "") {
+        if (!_creds->get_cipher_string().empty()) {
             if (SSL_CTX_set_cipher_list(ssl_ctx.get(),
-            _creds->get_priority_string().c_str()) != 1) {
-                throw ossl_error::make_ossl_error("Failed to set priority list");
+                    _creds->get_cipher_string().c_str()) != 1) {
+                throw ossl_error::make_ossl_error(
+                    fmt::format(
+                        "Failed to set cipher string '{}'", _creds->get_cipher_string()));
             }
         }
+
+        if (!_creds->get_ciphersuites().empty()) {
+            if (SSL_CTX_set_ciphersuites(ssl_ctx.get(), _creds->get_ciphersuites().c_str()) != 1) {
+                throw ossl_error::make_ossl_error(
+                    fmt::format(
+                        "Failed to set ciphersuites '{}'", _creds->get_ciphersuites()));
+            }
+        }
+
         return ssl_ctx;
     }
 

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -215,9 +215,33 @@ void tls::credentials_builder::set_client_auth(client_auth auth) {
     _client_auth = auth;
 }
 
+#ifndef SEASTAR_WITH_TLS_OSSL
 void tls::credentials_builder::set_priority_string(const sstring& prio) {
     _priority = prio;
 }
+#endif
+
+#ifdef SEASTAR_WITH_TLS_OSSL
+void tls::credentials_builder::set_cipher_string(const sstring& cipher_string) {
+    _cipher_string = cipher_string;
+}
+
+void tls::credentials_builder::set_ciphersuites(const sstring& ciphersuites) {
+    _ciphersuites = ciphersuites;
+}
+
+void tls::credentials_builder::enable_server_precedence() {
+    _enable_server_precedence = true;
+}
+
+void tls::credentials_builder::set_minimum_tls_version(tls_version version) {
+    _min_tls_version.emplace(version);
+}
+
+void tls::credentials_builder::set_maximum_tls_version(tls_version version) {
+    _max_tls_version.emplace(version);
+}
+#endif
 
 template<typename Blobs, typename Visitor>
 static void visit_blobs(Blobs& blobs, Visitor&& visitor) {
@@ -261,9 +285,33 @@ void tls::credentials_builder::apply_to(certificate_credentials& creds) const {
         creds.enable_load_system_trust();
     }
 
+#ifndef SEASTAR_WITH_TLS_OSSL
     if (!_priority.empty()) {
         creds.set_priority_string(_priority);
     }
+#endif
+
+#ifdef SEASTAR_WITH_TLS_OSSL
+    if (!_cipher_string.empty()) {
+        creds.set_cipher_string(_cipher_string);
+    }
+
+    if (!_ciphersuites.empty()) {
+        creds.set_ciphersuites(_ciphersuites);
+    }
+
+    if (_enable_server_precedence) {
+        creds.enable_server_precedence();
+    }
+
+    if (_min_tls_version.has_value()) {
+        creds.set_minimum_tls_version(*_min_tls_version);
+    }
+
+    if (_max_tls_version.has_value()) {
+        creds.set_maximum_tls_version(*_max_tls_version);
+    }
+#endif
 
     creds.set_client_auth(_client_auth);
 }
@@ -673,6 +721,19 @@ std::string_view tls::format_as(subject_alt_name_type type) {
             return "DIRNAME";
         default:
             return "UNKNOWN";
+    }
+}
+
+std::ostream& tls::operator<<(std::ostream& os, const tls_version & version) {
+    switch(version) {
+    case tls::tls_version::tlsv1_0:
+        return os << "TLSv1.0";
+    case tls::tls_version::tlsv1_1:
+        return os << "TLSv1.1";
+    case tls::tls_version::tlsv1_2:
+        return os << "TLSv1.2";
+    case tls::tls_version::tlsv1_3:
+        return os << "TLSv1.3";
     }
 }
 

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -160,6 +160,18 @@ SEASTAR_TEST_CASE(test_x509_client_with_builder_system_trust_multiple) {
     });
 }
 
+static void set_priority_string(tls::credentials_builder & b, const sstring & prio, [[maybe_unused]] bool is_tls_v13 = false) {
+#ifndef SEASTAR_WITH_TLS_OSSL
+    b.set_priority_string(prio);
+#else
+    if (is_tls_v13) {
+        b.set_ciphersuites(prio);
+    } else {
+        b.set_cipher_string(prio);
+    }
+#endif
+}
+
 SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings) {
 #ifdef SEASTAR_WITH_TLS_OSSL
     static std::vector<sstring> prios( {
@@ -186,7 +198,7 @@ SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings) {
     return do_for_each(prios, [](const sstring & prio) {
         tls::credentials_builder b;
         (void)b.set_system_trust();
-        b.set_priority_string(prio);
+        set_priority_string(b, prio);
         return connect_to_ssl_google(b.build_certificate_credentials());
     });
 }
@@ -204,7 +216,11 @@ SEASTAR_TEST_CASE(test_x509_client_with_system_trust_and_priority_strings_fail) 
     return do_for_each(prios, [](const sstring & prio) {
         tls::credentials_builder b;
         (void)b.set_system_trust();
-        b.set_priority_string(prio);
+        set_priority_string(b, prio);
+#ifdef SEASTAR_WITH_TLS_OSSL
+        b.set_minimum_tls_version(tls::tls_version::tlsv1_0);
+        b.set_maximum_tls_version(tls::tls_version::tlsv1_1);
+#endif
         try {
             return connect_to_ssl_google(b.build_certificate_credentials()).then([] {
                 BOOST_FAIL("Expected exception");
@@ -342,7 +358,7 @@ SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings) {
     b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
     auto addr = server.addr();
     do_for_each(prios, [&b, addr](const sstring& prio) {
-        b.set_priority_string(prio);
+        set_priority_string(b, prio);
         return connect_to_ssl_addr(b.build_certificate_credentials(), addr);
     }).get();
 }
@@ -362,7 +378,74 @@ SEASTAR_THREAD_TEST_CASE(test_x509_client_with_priority_strings_fail) {
     b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
     auto addr = server.addr();
     do_for_each(prios, [&b, addr](const sstring& prio) {
-        b.set_priority_string(prio);
+        set_priority_string(b, prio);
+#ifdef SEASTAR_WITH_TLS_OSSL
+        b.set_minimum_tls_version(tls::tls_version::tlsv1_0);
+        b.set_maximum_tls_version(tls::tls_version::tlsv1_1);
+#endif
+        try {
+            return connect_to_ssl_addr(b.build_certificate_credentials(), addr).then([] {
+                BOOST_FAIL("Expected exception");
+            }).handle_exception([](auto ep) {
+                // ok.
+            });
+        } catch (...) {
+            // also ok
+        }
+        return make_ready_future<>();
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_x509_client_tls13) {
+#ifdef SEASTAR_WITH_TLS_OSSL
+    static std::vector<sstring> prios({
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
+    });
+#else
+    static std::vector<sstring> prios({
+        "NORMAL:-VERS-ALL:+VERS-TLS1.3:-CIPHER-ALL:+AES-128-GCM",
+        "NORMAL:-VERS-ALL:+VERS-TLS1.3:-CIPHER-ALL:+AES-256-GCM",
+        "NORMAL:-VERS-ALL:+VERS-TLS1.3:-CIPHER-ALL:+CHACHA20-POLY1305"
+    });
+#endif
+    tls::credentials_builder b;
+    https_server server;
+    b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
+    auto addr = server.addr();
+    do_for_each(prios, [&b, addr](const sstring& prio) {
+        BOOST_TEST_CHECKPOINT("Checking priority string " << prio);
+        set_priority_string(b, prio, true);
+#ifdef SEASTAR_WITH_TLS_OSSL
+        b.set_minimum_tls_version(tls::tls_version::tlsv1_3);
+        b.set_maximum_tls_version(tls::tls_version::tlsv1_3);
+#endif
+        return connect_to_ssl_addr(b.build_certificate_credentials(), addr);
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_x509_client_tls13_fail) {
+    #ifdef SEASTAR_WITH_TLS_OSSL
+    static std::vector<sstring> prios({
+        "TLS_AES_128_CCM_SHA256"
+    });
+#else
+    static std::vector<sstring> prios({
+        "NORMAL:-VERS-ALL:+VERS-TLS1.3:-CIPHER-ALL:+AES-128-CCM-8"
+    });
+#endif
+    tls::credentials_builder b;
+    https_server server;
+    b.set_x509_trust_file(server.cert(), tls::x509_crt_format::PEM).get();
+    auto addr = server.addr();
+    do_for_each(prios, [&b, addr](const sstring& prio) {
+        BOOST_TEST_CHECKPOINT("Checking priority string " << prio);
+        set_priority_string(b, prio, true);
+#ifdef SEASTAR_WITH_TLS_OSSL
+        b.set_minimum_tls_version(tls::tls_version::tlsv1_3);
+        b.set_maximum_tls_version(tls::tls_version::tlsv1_3);
+#endif
         try {
             return connect_to_ssl_addr(b.build_certificate_credentials(), addr).then([] {
                 BOOST_FAIL("Expected exception");


### PR DESCRIPTION
GnuTLS allows for setting priority and server precedence all through the GnuTLS priority system.  OpenSSL on the other hand, has different APIs to handle this.

- To set server precedence in GnuTLS, simply provide the string %SERVER_PRECEDENCE in the priority string.  For OpenSSL, the flag SSL_OP_CIPHER_SERVER_PREFERENCE must be passed to SSL_CTX_set_options

- GnuTLS's priority string can be used to set the priority for all versions of TLS.  For OpenSSL, to set the ciphers available in TLSv1.2 and below, the user must call SSL_CTX_set_cipher_list. For TLSv1.3, the call is SSL_CTX_set_ciphersuites

As the format of the cipher/priority strings are different between OpenSSL and GnuTLS, the user of Seastar would have to change their code in order to change the format to match the requirements of the underlying TLS provider.  Therefor, this change adds three new functions to credentials_builder and server_credentials that plumb through these strings/settings to OpenSSL and are no-ops in GnuTLS. Conversely, the set_priority_string function is a no-op when using OpenSSL.