### PR TITLE
net: Expose DNS error category

### DIFF
--- a/include/seastar/net/dns.hh
+++ b/include/seastar/net/dns.hh
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <system_error>
 #include <vector>
 #include <unordered_map>
 #include <memory>
@@ -148,6 +149,13 @@ future<sstring> resolve_addr(const inet_address&);
 future<std::vector<srv_record>> get_srv_records(dns_resolver::srv_proto proto,
                                                 const sstring& service,
                                                 const sstring& domain);
+
+/**
+ * Error handling.
+ *
+ * The error_category instance used by exceptions thrown by DNS
+ */
+ const std::error_category& error_category();
 
 }
 


### PR DESCRIPTION
In case user applications wish to examine and react to specific DNS errors, make `ares_error_category` accessible via
`seastar::net::dns::error_category()` in a similar fashion to `seastar::tls::error_category()`.