### PR TITLE
CORE-6796 apply upstream changes for TLS

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -504,6 +504,13 @@ public:
     client_auth get_client_auth() const {
         return _client_auth;
     }
+    void set_session_resume_mode(session_resume_mode m) {
+        _session_resume_mode = m;
+    }
+
+    session_resume_mode get_session_resume_mode() {
+        return _session_resume_mode;
+    }
 
     void set_dn_verification_callback(dn_callback cb) {
         _dn_callback = std::move(cb);
@@ -578,6 +585,7 @@ private:
     certkey_pair _cert_and_key;
     std::shared_ptr<tls::dh_params::impl> _dh_params;
     client_auth _client_auth = client_auth::NONE;
+    session_resume_mode _session_resume_mode = session_resume_mode::NONE;
     bool _load_system_trust = false;
     dn_callback _dn_callback;
     sstring _cipher_string;
@@ -681,6 +689,10 @@ void tls::certificate_credentials::enable_load_system_trust() {
 
 void tls::certificate_credentials::set_client_auth(client_auth ca) {
     _impl->set_client_auth(ca);
+}
+
+void tls::certificate_credentials::set_session_resume_mode(session_resume_mode m) {
+    _impl->set_session_resume_mode(m);
 }
 
 tls::server_credentials::server_credentials()
@@ -1376,6 +1388,14 @@ public:
         }
         return make_ready_future<result_t>(
           do_get_alt_name_information(peer_cert, types));
+    }
+
+    future<bool> is_resumed() override {
+        co_return false;
+    }
+
+    future<session_data> get_session_resume_data() override {
+        co_return session_data{};
     }
 
 private:

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -215,6 +215,10 @@ void tls::credentials_builder::set_client_auth(client_auth auth) {
     _client_auth = auth;
 }
 
+void tls::credentials_builder::set_session_resume_mode(session_resume_mode m) {
+    _session_resume_mode = m;
+}
+
 #ifndef SEASTAR_WITH_TLS_OSSL
 void tls::credentials_builder::set_priority_string(const sstring& prio) {
     _priority = prio;
@@ -314,6 +318,7 @@ void tls::credentials_builder::apply_to(certificate_credentials& creds) const {
 #endif
 
     creds.set_client_auth(_client_auth);
+    creds.set_session_resume_mode(_session_resume_mode);
 }
 
 shared_ptr<tls::certificate_credentials> tls::credentials_builder::build_certificate_credentials() const {
@@ -703,6 +708,14 @@ future<std::optional<session_dn>> tls::get_dn_information(connected_socket& sock
 
 future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types) {
     return get_tls_socket(socket)->get_alt_name_information(std::move(types));
+}
+
+future<bool> tls::check_session_is_resumed(connected_socket& socket) {
+    return get_tls_socket(socket)->check_session_is_resumed();
+}
+
+future<tls::session_data> tls::get_session_resume_data(connected_socket& socket) {
+    return get_tls_socket(socket)->get_session_resume_data();
 }
 
 std::string_view tls::format_as(subject_alt_name_type type) {

--- a/src/net/tls-impl.hh
+++ b/src/net/tls-impl.hh
@@ -65,6 +65,8 @@ public:
     virtual future<std::optional<session_dn>> get_distinguished_name() = 0;
     virtual seastar::net::connected_socket_impl & socket() const = 0;
     virtual future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type>) = 0;
+    virtual future<bool> is_resumed() = 0;
+    virtual future<session_data> get_session_resume_data() = 0;
 };
 
 struct session_ref {
@@ -146,6 +148,12 @@ public:
     }
     future<> wait_input_shutdown() override {
         return _session->socket().wait_input_shutdown();
+    }
+    future<bool> check_session_is_resumed() {
+        return _session->is_resumed();
+    }
+    future<session_data> get_session_resume_data() {
+        return _session->get_session_resume_data();
     }
 };
 

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -285,6 +285,18 @@ struct gnutls_datum : public gnutls_datum_t {
         data = nullptr;
         size = 0;
     }
+    gnutls_datum(const gnutls_datum&) = delete;
+    gnutls_datum& operator=(gnutls_datum&& other) {
+        if (this == &other) {
+            return *this;
+        }
+        if (data != nullptr) {
+            ::gnutls_free(data);
+        }
+        data = std::exchange(other.data, nullptr);
+        size = std::exchange(other.size, 0);
+        return *this;
+    }
     ~gnutls_datum() {
         if (data != nullptr) {
             ::gnutls_free(data);

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -279,6 +279,19 @@ tls::x509_cert::x509_cert(const blob& b, x509_crt_format fmt)
         : x509_cert(::seastar::make_shared<impl>(b, fmt)) {
 }
 
+// wrapper for gnutls_datum, with raii free
+struct gnutls_datum : public gnutls_datum_t {
+    gnutls_datum() {
+        data = nullptr;
+        size = 0;
+    }
+    ~gnutls_datum() {
+        if (data != nullptr) {
+            ::gnutls_free(data);
+        }
+    }
+};
+
 class tls::certificate_credentials::impl: public gnutlsobj {
 public:
     impl()
@@ -394,6 +407,20 @@ public:
     client_auth get_client_auth() const {
         return _client_auth;
     }
+    void set_session_resume_mode(session_resume_mode m) {
+        _session_resume_mode = m;
+        // (re-)generate session key
+        if (m != session_resume_mode::NONE) {
+            _session_resume_key = {};
+            gnutls_session_ticket_key_generate(&_session_resume_key);
+        }
+    }
+    session_resume_mode get_session_resume_mode() const {
+        return _session_resume_mode;
+    }
+    const gnutls_datum_t* get_session_resume_key() const {
+        return &_session_resume_key;
+    }
     void set_priority_string(const sstring& prio) {
         const char * err = prio.c_str();
         try {
@@ -431,9 +458,11 @@ private:
     std::unique_ptr<tls::dh_params::impl> _dh_params;
     std::unique_ptr<std::remove_pointer_t<gnutls_priority_t>, void(*)(gnutls_priority_t)> _priority;
     client_auth _client_auth = client_auth::NONE;
+    session_resume_mode _session_resume_mode = session_resume_mode::NONE;
     bool _load_system_trust = false;
     semaphore _system_trust_sem {1};
     dn_callback _dn_callback;
+    gnutls_datum _session_resume_key;
 };
 
 tls::certificate_credentials::certificate_credentials()
@@ -514,6 +543,10 @@ void tls::certificate_credentials::set_client_auth(client_auth ca) {
     _impl->set_client_auth(ca);
 }
 
+void tls::certificate_credentials::set_session_resume_mode(session_resume_mode m) {
+    _impl->set_session_resume_mode(m);
+}
+
 tls::server_credentials::server_credentials()
 #if GNUTLS_VERSION_NUMBER < 0x030600
     : server_credentials(dh_params{})
@@ -535,6 +568,11 @@ tls::server_credentials& tls::server_credentials::operator=(
 void tls::server_credentials::set_client_auth(client_auth ca) {
     _impl->set_client_auth(ca);
 }
+
+void tls::server_credentials::set_session_resume_mode(session_resume_mode m) {
+    _impl->set_session_resume_mode(m);
+}
+
 
 namespace tls {
 
@@ -581,8 +619,17 @@ public:
                     gnutls_certificate_server_set_request(*this, GNUTLS_CERT_REQUIRE);
                     break;
             }
+            // Maybe set up server session ticket support
+            switch (_creds->get_session_resume_mode()) {
+                case session_resume_mode::NONE: 
+                default:
+                    break;
+                case session_resume_mode::TLS13_SESSION_TICKET:
+                    gnutls_session_ticket_enable_server(*this, _creds->get_session_resume_key());
+                    break;
+            }
         }
-
+ 
         auto prio = _creds->get_priority();
         if (prio) {
             gtls_chk(gnutls_priority_set(*this, prio));
@@ -599,6 +646,11 @@ public:
             gnutls_session_set_verify_function(*this, &verify_wrapper);
         }
 #endif
+        // if we are a client, check if we have a session ticket to unpack.
+        if (_type == type::CLIENT && !_options.session_resume_data.empty()) {
+            gtls_chk(gnutls_session_set_data(*this, _options.session_resume_data.data(), _options.session_resume_data.size()));
+        }
+        _options.session_resume_data.clear(); // no need to keep around
     }
     session(type t, shared_ptr<certificate_credentials> creds,
             connected_socket sock,
@@ -1104,8 +1156,56 @@ public:
         });
     }
 
-    seastar::net::connected_socket_impl & socket() const {
+    seastar::net::connected_socket_impl& socket() const {
         return *_sock;
+    }
+
+    // helper routine.
+    template<typename Func, typename... Args>
+    auto state_checked_access(Func&& f, Args&& ...args) {
+        using future_type = typename futurize<std::invoke_result_t<Func, Args...>>::type;
+        using result_t = typename future_type::value_type;
+        if (_error) {
+            return make_exception_future<result_t>(_error);
+        }
+        if (_shutdown) {
+            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
+        }
+        if (!_connected) {
+            return handshake().then([this, f = std::move(f), ...args = std::forward<Args>(args)]() mutable {
+                // always recurse, in case malicious api caller does a shutdown while the above handshake is
+                // happening. I.e. misuses the api.
+                return session::state_checked_access(std::move(f), std::forward<Args>(args)...);
+            });
+        }
+        return futurize_invoke(f, std::forward<Args>(args)...);
+    }
+
+    future<bool> is_resumed() {
+        return state_checked_access([this] {
+            return gnutls_session_is_resumed(*this) != 0;
+        });
+    }
+    future<session_data> get_session_resume_data() {
+        return state_checked_access([this] {
+            /**
+             * Session ticket data is not available just because handshake 
+             * was done. First off, of course other part must support it,
+             * but we also (mostly?) need to actually transfer data before
+             * the ticket is received.
+             * 
+             * Check session flags so we can return no data in the case
+             * none is avail. Gnutls returns a 4-byte "empty marker" 
+             * on none avail.
+            */
+            auto flags = gnutls_session_get_flags(*this);
+            if ((flags & GNUTLS_SFLAGS_SESSION_TICKET) == 0) {
+                return session_data{};
+            }
+            gnutls_datum tmp;
+            gtls_chk(gnutls_session_get_data2(*this, &tmp));
+            return session_data(tmp.data, tmp.data + tmp.size);
+        });
     }
 
     future<std::optional<session_dn>> get_distinguished_name() {

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1207,45 +1207,20 @@ public:
             return session_data(tmp.data, tmp.data + tmp.size);
         });
     }
-
     future<std::optional<session_dn>> get_distinguished_name() {
-        using result_t = std::optional<session_dn>;
-        if (_error) {
-            return make_exception_future<result_t>(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
-        }
-        if (!_connected) {
-            return handshake().then([this]() mutable {
-               return get_distinguished_name();
-            });
-        }
-        result_t dn = extract_dn_information();
-        return make_ready_future<result_t>(std::move(dn));
-    }
+        return state_checked_access([this] {
+            return extract_dn_information();
+        });
+    }    
     future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) {
-        using result_t = std::vector<subject_alt_name>;
+        return state_checked_access([this](std::unordered_set<subject_alt_name_type> types) {
+            std::vector<subject_alt_name> res;
 
-        if (_error) {
-            return make_exception_future<result_t>(_error);
-        }
-        if (_shutdown) {
-            return make_exception_future<result_t>(std::system_error(ENOTCONN, std::system_category()));
-        }
-        if (!_connected) {
-            return handshake().then([this, types = std::move(types)]() mutable {
-               return get_alt_name_information(std::move(types));
-            });
-        }
+            auto peer = get_peer_certificate();
+            if (!peer) {
+                return res;
+            }
 
-        auto peer = get_peer_certificate();
-        if (!peer) {
-            return make_ready_future<result_t>();
-        }
-
-        return futurize_invoke([&] {
-            result_t res;
         	for (auto i = 0u; ; i++) {
                 size_t size = 0;
 
@@ -1311,7 +1286,7 @@ public:
                 res.emplace_back(std::move(v));
         	}
             return res;
-        });
+        }, std::move(types));
     }
 
     struct session_ref;

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1130,7 +1130,7 @@ SEASTAR_THREAD_TEST_CASE(test_reload_certificates_with_creds) {
         BOOST_CHECK(trust_list_info.has_value() && trust_list_info.value().empty());
         BOOST_CHECK(!trust_file_contents.has_value());
 
-    }).get0();
+    }).get();
 
     BOOST_CHECK(certs != nullptr);
 
@@ -1738,10 +1738,10 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
         fout.get();
         fin.get();
 
-        BOOST_REQUIRE(!tls::check_session_is_resumed(c).get0()); // no resume data
+        BOOST_REQUIRE(!tls::check_session_is_resumed(c).get()); // no resume data
 
         // get ticket data
-        sess_data = tls::get_session_resume_data(c).get0();
+        sess_data = tls::get_session_resume_data(c).get();
         BOOST_REQUIRE(!sess_data.empty());
 
         in.close().get();
@@ -1781,7 +1781,7 @@ SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
         fout.get();
         fin.get();
 
-        BOOST_REQUIRE(f.get0()); // Should work
+        BOOST_REQUIRE(f.get()); // Should work
 
         in.close().get();
         out.close().get();

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1685,3 +1685,112 @@ SEASTAR_THREAD_TEST_CASE(test_skip_wait_for_eof) {
     }
 }
 
+/**
+ * Test TLS13 session ticket support.
+*/
+SEASTAR_THREAD_TEST_CASE(test_tls13_session_tickets) {
+    tls::credentials_builder b;
+
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_session_resume_mode(tls::session_resume_mode::TLS13_SESSION_TICKET);
+#ifdef SEASTAR_WITH_TLS_OSSL
+    b.set_minimum_tls_version(tls::tls_version::tlsv1_3);
+#else
+    b.set_priority_string("SECURE128:+SECURE192:-VERS-TLS-ALL:+VERS-TLS1.3");
+#endif
+
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    ::listen_options opts;
+    opts.reuse_address = true;
+    opts.set_fixed_cpu(this_shard_id());
+
+    auto addr = ::make_ipv4_address( {0x7f000001, 4712});
+    auto server = tls::listen(serv, addr, opts);
+
+    tls::session_data sess_data;
+
+    {
+        auto sa = server.accept();
+        auto c = tls::connect(creds, addr).get();
+        auto s = sa.get();
+
+        auto in = s.connection.input();
+        auto cin = c.input();
+        output_stream<char> out(c.output().detach(), 1024);
+        output_stream<char> sout(s.connection.output().detach(), 1024);
+
+        // write data in both directions. Required for session data to 
+        // become available. 
+        out.write("nils").get();
+        auto fin = in.read();
+        auto fout = out.flush();
+
+        fout.get();
+        fin.get();
+
+        sout.write("banan").get();
+        fin = cin.read();
+        fout = sout.flush();
+
+        fout.get();
+        fin.get();
+
+        BOOST_REQUIRE(!tls::check_session_is_resumed(c).get0()); // no resume data
+
+        // get ticket data
+        sess_data = tls::get_session_resume_data(c).get0();
+        BOOST_REQUIRE(!sess_data.empty());
+
+        in.close().get();
+        out.close().get();
+
+        s.connection.shutdown_input();
+        s.connection.shutdown_output();
+
+        c.shutdown_input();
+        c.shutdown_output();
+    }
+
+
+    {
+        auto sa = server.accept();
+
+        // tell client to try resuming.
+        tls::tls_options tls_opts;
+        tls_opts.session_resume_data = sess_data;
+
+        auto c = tls::connect(creds, addr, tls_opts).get();
+        auto s = sa.get();
+
+        // This is ok. Will force a handshake.
+        auto f = tls::check_session_is_resumed(c);
+
+        // But we need to force some IO to make the 
+        // handshake actually happen.
+        auto in = s.connection.input();
+        output_stream<char> out(c.output().detach(), 1024);
+
+        auto fin = in.read();
+
+        out.write("nils").get();
+        auto fout = out.flush();
+
+        fout.get();
+        fin.get();
+
+        BOOST_REQUIRE(f.get0()); // Should work
+
+        in.close().get();
+        out.close().get();
+
+        s.connection.shutdown_input();
+        s.connection.shutdown_output();
+
+        c.shutdown_input();
+        c.shutdown_output();
+    }
+
+}


### PR DESCRIPTION
This PR cherry-picks a number of commits from upstream to help ensure a smaller divergence.

What is important is the first commit that adds support for TLS1.3 session tickets.

**IMPORTANT**

This _does not_ implement session resumption in OpenSSL.  A follow on change will implement this feature.  The Seastar TLS unit test will fail when built using OpenSSL.