### PR TITLE
core: make reference counting in `deleter` atomic

### DIFF
--- a/include/seastar/core/deleter.hh
+++ b/include/seastar/core/deleter.hh
@@ -31,7 +31,15 @@
 #include <seastar/util/modules.hh>
 #endif
 
+// The forward declarations of classes below are used for 
+// friending by the deleter.
+class test_deleter_append_does_not_free_shared_object;
+class test_deleter_append_same_shared_object_twice;
+
 namespace seastar {
+namespace net {
+    class packet;
+};
 
 /// \addtogroup memory-module
 /// @{
@@ -87,11 +95,19 @@ public:
         this->~deleter();
         new (this) deleter(i);
     }
+private:
     /// \endcond
     /// Appends another deleter to this deleter.  When this deleter is
     /// destroyed, both encapsulated actions will be carried out.
+    ///
+    /// This operation is not thread-safe and therefore not made public
+    /// except for a few manually verified uses that are marked as freinds
+    /// below.
     void append(deleter d);
-private:
+    friend class ::seastar::net::packet;
+    friend class ::test_deleter_append_does_not_free_shared_object;
+    friend class ::test_deleter_append_same_shared_object_twice;
+
     static bool is_raw_object(impl* i) noexcept {
         auto x = reinterpret_cast<uintptr_t>(i);
         return x & 1;


### PR DESCRIPTION
Seastar's `deleter` is used in `temporary_buffer` and a couple of other classes. By making the reference counting in it atomic we make sharing `temporary_buffer`s in a read-only manner across shards safe.