### PR TITLE
Add `hdr_hist` to `temporary_buffer`'s friends

### DIFF
--- a/include/seastar/core/temporary_buffer.hh
+++ b/include/seastar/core/temporary_buffer.hh
@@ -32,6 +32,8 @@
 #include <seastar/util/std-compat.hh>
 #include <seastar/util/modules.hh>
 
+class hdr_hist; // Class from Redpanda
+
 namespace seastar {
 
 /*
@@ -145,6 +147,7 @@ private:
     friend class ::seastar::file_data_source_impl;
     friend class ::seastar::net::packet_data_source;
     friend class ::seastar::file;
+    friend class ::hdr_hist;
 
     template<typename T> 
     friend T rpc::make_shard_local_buffer_copy(foreign_ptr<std::unique_ptr<T>> org);


### PR DESCRIPTION
`hdr_hist` uses the method to make a raw buffer a temporary_buffer