### PR TITLE
[v24.2.x] net: avoid propagating openssl system errors to errno

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1931,12 +1931,10 @@ int bio_write_ex(BIO* b, const char * data, size_t dlen, size_t * written) {
         
         return 1;
     } catch(const std::system_error & e) {
-        errno = e.code().value();
-        ERR_raise_data(ERR_LIB_SYS, errno, e.what());
+        ERR_raise_data(ERR_LIB_SYS, e.code().value(), e.what());
         session->_output_pending = make_exception_future<>(std::current_exception());
     } catch(...) {
-        errno = EIO;
-        ERR_raise(ERR_LIB_SYS, errno);
+        ERR_raise(ERR_LIB_SYS, EIO);
         session->_output_pending = make_exception_future<>(std::current_exception());
     }
     

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1163,7 +1163,7 @@ public:
                     // return an empty buffer (the get() function will initiate a handshake)
                     return make_ready_future<buf_type>();
                 case SSL_ERROR_SYSCALL:
-                    if (errno == 0 && ERR_peek_error() == 0) {
+                    if (ERR_peek_error() == 0) {
                         // SSL_get_error
                         // (https://www.openssl.org/docs/man3.0/man3/SSL_get_error.html)
                         // states that on OpenSSL versions prior to 3.0, an

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -149,14 +149,6 @@ std::system_error make_ossl_error(const std::string & msg) {
     }
 }
 
-std::system_error make_error_from_errno(const std::string & msg) {
-    if (errno == 0) {
-        return make_ossl_error(msg);
-    } else {
-        return std::system_error(errno, std::generic_category(), msg);
-    }
-}
-
 template<typename T>
 sstring asn1_str_to_str(T* asn1) {
     const auto len = ASN1_STRING_length(asn1);
@@ -907,7 +899,7 @@ public:
             return make_ready_future<stop_iteration>(stop_iteration::no);
         case SSL_ERROR_SYSCALL:
         {
-            auto err = make_error_from_errno("System error encountered during SSL write");
+            auto err = make_ossl_error("System error encountered during SSL write");
             return handle_output_error(std::move(err)).then([] {
                 return stop_iteration::yes;
             });
@@ -1066,7 +1058,7 @@ public:
                             });
                         case SSL_ERROR_SYSCALL:
                         {
-                            auto err = make_error_from_errno("System error during handshake");
+                            auto err = make_ossl_error("System error during handshake");
                             return handle_output_error(std::move(err));
                         }
                         case SSL_ERROR_SSL:
@@ -1186,7 +1178,7 @@ public:
                         return make_ready_future<buf_type>();
                     }
                     _error = std::make_exception_ptr(
-                        make_error_from_errno("System error during SSL read"));
+                        make_ossl_error("System error during SSL read"));
                     return make_exception_future<buf_type>(_error);
                 case SSL_ERROR_SSL:
                     {
@@ -1269,7 +1261,7 @@ public:
                 });
             case SSL_ERROR_SYSCALL:
             {
-                auto err = make_error_from_errno("System error during shutdown");
+                auto err = make_ossl_error("System error during shutdown");
                 return handle_output_error(std::move(err));
             }
             case SSL_ERROR_SSL:


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/seastar/pull/153

When there is an error while trying to write to the underlying socket
inside the bio write method, we should signal that error by propagating
it on openssl's internal error stack rather than through setting errno.

Using the error stack is openssl's conventional way of communicating
errors, so we should use it instead of relying on errno. Writing to
errno is problematic because it may be read by other parts of the
system and this "poisoning" of the global errno variable could cause
unexpected errors inside other parts of the system.

The issue arises from the OpenSSL error stack not being cleared when a system error occurs, such as an EPIPE error when the remote end closes the connection. If the error stack is not purged, subsequent TLS operations may fail due to the lingering error.

In Seastar applications, writing data over a TLS socket involves the session's [put()](https://github.com/redpanda-data/seastar/blob/2380681a29718c1e5760cb8559de4f6d487a6572/src/net/ossl.cc#L992-L1028) function, which calls OpenSSL's [SSL_write_ex](https://github.com/redpanda-data/seastar/blob/2380681a29718c1e5760cb8559de4f6d487a6572/src/net/ossl.cc#L964-L965). This function encrypts the data and writes it to the output BIO, which invokes [bio_write_ex](https://github.com/redpanda-data/seastar/blob/2380681a29718c1e5760cb8559de4f6d487a6572/src/net/ossl.cc#L1900-L1944) to write the data to the TLS session's [data sink](https://github.com/redpanda-data/seastar/blob/2380681a29718c1e5760cb8559de4f6d487a6572/src/net/ossl.cc#L1766). If a previous write has failed, bio_write_ex checks [_output_pending.failed()](https://github.com/redpanda-data/seastar/blob/2380681a29718c1e5760cb8559de4f6d487a6572/src/net/ossl.cc#L1933-L1941), throws the exception, pushes the error onto the OpenSSL stack, and returns 0, which propagates the failure to SSL_write_ex.

When SSL_write_ex or similar functions fail, the application uses [SSL_get_error](https://docs.openssl.org/3.0/man3/SSL_get_error/) to determine the cause. Non-fatal conditions like SSL_ERROR_WANT_READ or SSL_ERROR_WANT_WRITE indicate retryable states and are handled with session calls to wait_for_input() or wait_for_output(). However, fatal conditions like SSL_ERROR_SYSCALL or SSL_ERROR_SSL depend on the earliest error in the stack, as seen [here](https://github.com/openssl/openssl/blob/c523121f902fde2929909dc7f76b13ceb4961efe/ssl/ssl_lib.c#L3870-L3875).

The current issue is that when [SSL_ERROR_SYSCALL is returned](https://github.com/redpanda-data/seastar/blob/2380681a29718c1e5760cb8559de4f6d487a6572/src/net/ossl.cc#L908-L914), and errno is non-zero, a [std::system_error](https://github.com/redpanda-data/seastar/blob/2380681a29718c1e5760cb8559de4f6d487a6572/src/net/ossl.cc#L152-L158) is thrown, but the error stack is not cleared. As a result, other TLS sessions on the same thread may encounter a latent error when calling SSL_get_error, even if no issue occurred in those sessions.

The proposed change resolves this by always draining the error stack when SSL_ERROR_SYSCALL is returned from SSL_get_error. This ensures the error stack is cleaned, preventing subsequent operations on other TLS sessions from failing due to residual errors.