### PR TITLE
when_all: stop using deprecated std::aligned_union_t

### DIFF
--- a/include/seastar/core/when_all.hh
+++ b/include/seastar/core/when_all.hh
@@ -145,7 +145,7 @@ class when_all_state : public when_all_state_base {
     // We only schedule one continuation at a time, and store it in _cont.
     // This way, if while the future we wait for completes, some other futures
     // also complete, we won't need to schedule continuations for them.
-    std::aligned_union_t<1, when_all_state_component<Futures>...> _cont;
+    alignas(when_all_state_component<Futures>...) std::byte _cont[std::max({sizeof(when_all_state_component<Futures>)...})];
     when_all_process_element _processors[nr];
 public:
     typename ResolvedTupleTransform::promise_type p;


### PR DESCRIPTION
since [P1413R3](https://wg21.link/p1413r3) was accepted by C++23, std::aligned_union_t was deprecated in this standard. so let's be prepared for this. as suggested by the proposal, we are replacing `std::aligned_union_t` with an array of `std::byte`.