### PR TITLE
tls/ossl: Added option to enable TLS renegotiation

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -258,6 +258,10 @@ namespace tls {
          * If unset, will default to the maximum of the underly implementation
          */
         void set_maximum_tls_version(tls_version);
+        /**
+         * @brief Permits TLS renegotiation on TLSv1.2 and below connections
+         */
+        void enable_tls_renegotiation();
 #endif
 
         /**
@@ -391,6 +395,7 @@ namespace tls {
         void enable_server_precedence();
         void set_minimum_tls_version(tls_version);
         void set_maximum_tls_version(tls_version);
+        void enable_tls_renegotiation();
 #endif
 
         void apply_to(certificate_credentials&) const;
@@ -416,6 +421,7 @@ namespace tls {
         sstring _cipher_string;
         sstring _ciphersuites;
         bool _enable_server_precedence = false;
+        bool _enable_tls_renegotiation = false;
         std::optional<tls_version> _min_tls_version;
         std::optional<tls_version> _max_tls_version;
     };

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -593,6 +593,10 @@ public:
         _enable_server_precedence = true;
     }
 
+    void enable_tls_renegotiation() {
+        _enable_tls_renegotiation = true;
+    }
+
     void set_minimum_tls_version(tls_version version) {
         _min_tls_version.emplace(version);
     }
@@ -611,6 +615,10 @@ public:
 
     bool is_server_precedence_enabled() {
         return _enable_server_precedence;
+    }
+
+    bool is_tls_renegotiation_enabled() {
+        return _enable_tls_renegotiation;
     }
 
     const std::optional<tls_version>& minimum_tls_version() const noexcept {
@@ -658,6 +666,7 @@ private:
     session_resume_mode _session_resume_mode = session_resume_mode::NONE;
     bool _load_system_trust = false;
     bool _enable_server_precedence = false;
+    bool _enable_tls_renegotiation = false;
     bool _crl_check_flag_set = false;
 
 };
@@ -709,6 +718,10 @@ void tls::certificate_credentials::set_ciphersuites(const sstring& ciphersuites)
 
 void tls::certificate_credentials::enable_server_precedence() {
     _impl->enable_server_precedence();
+}
+
+void tls::certificate_credentials::enable_tls_renegotiation() {
+    _impl->enable_tls_renegotiation();
 }
 
 void tls::certificate_credentials::set_minimum_tls_version(tls_version version) {
@@ -1659,9 +1672,13 @@ private:
                 break;
             }
 
-            auto options = SSL_OP_ALL | SSL_OP_ALLOW_CLIENT_RENEGOTIATION;
+            auto options = SSL_OP_ALL;
             if (_creds->is_server_precedence_enabled()) {
                 options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+            }
+
+            if (_creds->is_tls_renegotiation_enabled()) {
+                options |= SSL_OP_ALLOW_CLIENT_RENEGOTIATION;
             }
 
             SSL_CTX_set_options(ssl_ctx.get(), options);

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -238,6 +238,10 @@ void tls::credentials_builder::enable_server_precedence() {
     _enable_server_precedence = true;
 }
 
+void tls::credentials_builder::enable_tls_renegotiation() {
+    _enable_tls_renegotiation = true;
+}
+
 void tls::credentials_builder::set_minimum_tls_version(tls_version version) {
     _min_tls_version.emplace(version);
 }
@@ -306,6 +310,10 @@ void tls::credentials_builder::apply_to(certificate_credentials& creds) const {
 
     if (_enable_server_precedence) {
         creds.enable_server_precedence();
+    }
+
+    if (_enable_tls_renegotiation) {
+        creds.enable_tls_renegotiation();
     }
 
     if (_min_tls_version.has_value()) {


### PR DESCRIPTION
TLS client renegotiation was removed in TLSv1.3 due to vulnerabilities found in the protocol.  For safety reasons, it is by default disabled, however an option is provided to re-enable it if desired.