### PR TITLE
thread: do not use fortify source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,10 +796,6 @@ add_library (seastar
   src/websocket/server.cc
   )
 
-# We disable _FORTIFY_SOURCE because it generates false positives with longjmp() (src/core/thread.cc)
-set_source_files_properties(src/core/thread.cc
-  PROPERTIES COMPILE_FLAGS -U_FORTIFY_SOURCE)
-
 add_library (Seastar::seastar ALIAS seastar)
 
 add_dependencies (seastar

--- a/src/core/thread.cc
+++ b/src/core/thread.cc
@@ -1,3 +1,8 @@
+// If _FORTIFY_SOURCE is defined then longjmp ends up using longjmp_chk
+// which asserts that you're jumping to the same stack. However, here we
+// are intentionally switching stacks when longjmp'ing, so undefine this
+// option to always use normal longjmp.
+#undef _FORTIFY_SOURCE
 /*
  * This file is open source software, licensed to you under the terms
  * of the Apache License, Version 2.0 (the "License").  See the NOTICE file


### PR DESCRIPTION
It causes problems with longjmp

    *** longjmp causes uninitialized stack frame ***: terminated
    Aborting on shard 0.
    Backtrace:

which was taken care of in the cmake build, but needs to be fixed in our bazel build. reference: scylladb/seastar#2344

Closes #2522

(cherry picked from commit c96444fbe43acac0d31418b65b04395c11fdda14)