### PR TITLE
Tls cert race/core 9178/v25.1.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,6 +88,7 @@ jobs:
             --compiler ${{ inputs.compiler }}     \
             --c-compiler $CC                      \
             --mode ${{ inputs.mode }}             \
+            --ssl-provider OpenSSL                \
             $MAYBE_CCACHE_OPT                     \
             ${{ inputs.options }}                 \
             ${{ inputs.enables }}

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -44,6 +44,7 @@ debian_packages=(
     libpciaccess-dev
     libprotobuf-dev
     libsctp-dev
+    libssl-dev
     libtool
     liburing-dev
     libxml2-dev
@@ -96,6 +97,7 @@ redhat_packages=(
     meson
     numactl-devel
     openssl
+    openssl-devel
     protobuf-compiler
     protobuf-devel
     python3
@@ -227,6 +229,7 @@ opensuse_packages=(
     meson
     ninja
     openssl
+    openssl-devel
     protobuf-devel
     python3-PyYAML
     ragel

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -567,7 +567,7 @@ function(seastar_add_certgen name)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAROOT}"
-    COMMAND ${OPENSSL} req -x509 -new -nodes -key ${CERT_CAPRIVKEY} -days ${CERT_DAYS} -config ${CERT_NAME}.cfg -out ${CERT_CAROOT}
+    COMMAND ${OPENSSL} req -x509 -new -nodes -key ${CERT_CAPRIVKEY} -days ${CERT_DAYS} -config ${CERT_NAME}.cfg -out ${CERT_CAROOT} -extensions v3_ca
     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${CERT_CAPRIVKEY}" "${CMAKE_CURRENT_BINARY_DIR}/${CERT_NAME}.cfg"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )


### PR DESCRIPTION
Fixes: CORE-9178

This addresses a possible race condition that some customers have witnessed where Seastar was not returning the correct certificate and this caused authorization failures on the broker. The fix is to use the correct OpenSSL API (SSL_get1_peer_certificate) rather than the cert held by the callback.

Note: We will backport this to v24.3 and v24.2 to address this bug in all OpenSSL implementations