### PR TITLE
memory: remove libnuma dependency

### DIFF
--- a/cooking_recipe.cmake
+++ b/cooking_recipe.cmake
@@ -110,7 +110,7 @@ cooking_ingredient (nettle
     BUILD_COMMAND <DISABLE>
     INSTALL_COMMAND ${make_command} install)
 
-# Also a direct dependency of Seastar.
+# A dependency of DPDK.
 cooking_ingredient (numactl
   EXTERNAL_PROJECT_ARGS
     URL https://github.com/numactl/numactl/releases/download/v2.0.12/numactl-2.0.12.tar.gz

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,10 +130,6 @@ target_link_libraries (seastar-module
     yaml-cpp::yaml-cpp
     "$<BUILD_INTERFACE:Valgrind::valgrind>"
     Threads::Threads)
-if (Seastar_NUMA)
-  target_link_libraries (seastar-module
-    PRIVATE numactl::numactl)
-endif ()
 if (Seastar_HWLOC)
   target_link_libraries (seastar-module
     PRIVATE hwloc::hwloc)


### PR DESCRIPTION
Seastar is currently pulling in all of libnuma to just invoke a single syscall. Additionally since libnuma being LGPL licensed, it's simpler to not include it as a dependency. Replace the call in numaif.h with a direct syscall.

I'm assuming that once libnuma was depended on because it was a dependency of hwloc, however, hwloc version 2 removed the dependency on libnuma, so Seastar can too:
https://github.com/open-mpi/hwloc/blob/263908a2c1f21c0e221a8d1f6472daf3a1fc07b9/NEWS#L291

(cherry picked from commit 8ab0267117de9f0a0dabfeb0fd54227a428eefe1)