### PR TITLE
tls: Added support for fetching DN in RFC2253 format

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -531,6 +531,11 @@ namespace tls {
     server_socket listen(shared_ptr<server_credentials>, server_socket);
     /// @}
 
+    enum class dn_format {
+        legacy, // legacy format
+        rfc2253
+    };
+
     /**
      * Get distinguished name from the leaf certificate in the certificate chain that
      * the connected peer is using.
@@ -541,7 +546,7 @@ namespace tls {
      * during the handshake the function returns nullopt. If the socket is not connected the
      * system_error exception will be thrown.
      */
-    future<std::optional<session_dn>> get_dn_information(connected_socket& socket);
+    future<std::optional<session_dn>> get_dn_information(connected_socket& socket, dn_format format = dn_format::legacy);
 
     /**
      * Subject alt name types. 

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -710,8 +710,8 @@ static tls::tls_connected_socket_impl* get_tls_socket(connected_socket& socket) 
     return tls_impl;
 }
 
-future<std::optional<session_dn>> tls::get_dn_information(connected_socket& socket) {
-    return get_tls_socket(socket)->get_distinguished_name();
+future<std::optional<session_dn>> tls::get_dn_information(connected_socket& socket, dn_format format) {
+    return get_tls_socket(socket)->get_distinguished_name(format);
 }
 
 future<std::vector<tls::subject_alt_name>> tls::get_alt_name_information(connected_socket& socket, std::unordered_set<subject_alt_name_type> types) {

--- a/src/net/tls-impl.hh
+++ b/src/net/tls-impl.hh
@@ -62,7 +62,7 @@ public:
     virtual future<> flush() noexcept = 0;
     virtual future<temporary_buffer<char>> get() = 0;
     virtual void close() = 0;
-    virtual future<std::optional<session_dn>> get_distinguished_name() = 0;
+    virtual future<std::optional<session_dn>> get_distinguished_name(dn_format) = 0;
     virtual seastar::net::connected_socket_impl & socket() const = 0;
     virtual future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type>) = 0;
     virtual future<bool> is_resumed() = 0;
@@ -140,8 +140,8 @@ public:
     socket_address remote_address() const noexcept override {
         return _session->socket().remote_address();
     }
-    future<std::optional<session_dn>> get_distinguished_name() {
-        return _session->get_distinguished_name();
+    future<std::optional<session_dn>> get_distinguished_name(dn_format format) {
+        return _session->get_distinguished_name(format);
     }
     future<std::vector<subject_alt_name>> get_alt_name_information(std::unordered_set<subject_alt_name_type> types) {
         return _session->get_alt_name_information(std::move(types));

--- a/src/net/tls.cc
+++ b/src/net/tls.cc
@@ -1221,7 +1221,8 @@ public:
             return session_data(tmp.data, tmp.data + tmp.size);
         });
     }
-    future<std::optional<session_dn>> get_distinguished_name() {
+    future<std::optional<session_dn>> get_distinguished_name(dn_format) {
+        // Ignoring parameter as GnuTLS does not provide a mechanism to change the format
         return state_checked_access([this] {
             return extract_dn_information();
         });

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -1549,6 +1549,11 @@ SEASTAR_THREAD_TEST_CASE(test_dn_name_handling) {
         BOOST_REQUIRE_EQUAL(dn->subject, fmt::format("C=GB,ST=London,L=London,O=Redpanda Data,OU=Core,CN={}", id));
         BOOST_REQUIRE_EQUAL(dn->issuer, "C=GB,ST=London,L=London,O=Redpanda Data,OU=Core,CN=redpanda.com");
 
+        dn = tls::get_dn_information(s.connection, tls::dn_format::rfc2253).get();
+        BOOST_REQUIRE(dn.has_value());
+        BOOST_REQUIRE_EQUAL(dn->subject, fmt::format("CN={},OU=Core,O=Redpanda Data,L=London,ST=London,C=GB", id));
+        BOOST_REQUIRE_EQUAL(dn->issuer, "CN=redpanda.com,OU=Core,O=Redpanda Data,L=London,ST=London,C=GB");
+
         auto client_id = fin.get();
 
         in.close().get();


### PR DESCRIPTION
Added a dn_format flag to switch between legacy and RFC2253 format. Legacy format matches that originally returned by the GnuTLS api `gnutls_x509_crt_get_dn` which returns the DN in the format of `C=US,ST=London,L=London,O=Redpanda Data,OU=Core,CN=id`.  RFC2253 format, effectively reverses the order: `CN=id,OU=Core,O=Redpanda Data,L=London,ST=London,C=US`.

Signed-off-by: Michael Boquard <michael@redpanda.com>
(cherry picked from commit dad4af6b02e97ca17ec1a394e4370811e4375523)