### PR TITLE
`http`: add `xml` support to `http::mime_types::mappings`

### DIFF
--- a/src/http/mime_types.cc
+++ b/src/http/mime_types.cc
@@ -25,6 +25,7 @@ struct mapping {
     const char* mime_type;
 } mappings[] = {
         { "json", "application/json"},
+	{ "xml", "application/xml"},
         { "gif", "image/gif" },
         { "htm", "text/html" },
         { "css", "text/css" },


### PR DESCRIPTION
It seems strange that `xml` isn't supported as a `mime` type here. [We expect all S3 REST error responses ](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#RESTErrorResponses)to be returned with a `Content-Type` header of `application/xml`, so being able to map the extension here makes life a lot easier for testing with imposter `http` S3 servers/services.

Motivated by having to fix tests for https://github.com/redpanda-data/redpanda/pull/25738.