### PR TITLE
file_io/output_stream: avoid unnecessary allocation if no write_behind

### DIFF
--- a/src/core/fstream.cc
+++ b/src/core/fstream.cc
@@ -384,7 +384,9 @@ public:
     file_data_sink_impl(file f, file_output_stream_options options)
             : _file(std::move(f)), _options(options) {
         _options.buffer_size = select_buffer_size<unsigned>(_options.buffer_size, _file.disk_write_max_length());
-        _write_behind_sem.ensure_space_for_waiters(1); // So that wait() doesn't throw
+	if (_options.write_behind) {
+	    _write_behind_sem.ensure_space_for_waiters(1); // So that wait() doesn't throw
+	}
     }
     future<> put(net::packet data) override { abort(); }
     virtual temporary_buffer<char> allocate_buffer(size_t size) override {


### PR DESCRIPTION
ensure_space_for_waiters allocates a chunk of waiters which is not needed if no write_behind is configured. A tiny optimization but with a lot of file output streams, this seems to add up to non trivial memory usage.