### PR TITLE
Downstream stall notifier fixes

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1541,7 +1541,11 @@ void cpu_stall_detector::generate_trace() {
     buf.append("Reactor stalled for ");
     buf.append_decimal(uint64_t(delta / 1ms));
     buf.append(" ms");
-    print_with_backtrace(buf, _config.oneline);
+    if (std::uncaught_exceptions() > 0) {
+        buf.append(", backtrace omitted (uncaught exception in progress)\n");
+    } else {
+        print_with_backtrace(buf, _config.oneline);
+    }
     maybe_report_kernel_trace();
 }
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4082,7 +4082,7 @@ void smp::create_thread(std::function<void ()> thread_loop) {
 
 // Installs handler for Signal which ensures that Func is invoked only once
 // in the whole program and that after it is invoked the default handler is restored.
-template<int Signal, void(*Func)()>
+template<int Signal, void(*Func)(siginfo_t *, ucontext_t *)>
 void install_oneshot_signal_handler() {
     static bool handled = false;
     static util::spinlock lock;
@@ -4093,7 +4093,7 @@ void install_oneshot_signal_handler() {
         if (!handled) {
             handled = true;
             signal(sig, SIG_DFL);
-            Func();
+            Func(info, (ucontext_t *)p);
         }
     };
     sigfillset(&sa.sa_mask);
@@ -4110,12 +4110,58 @@ static void reraise_signal(int signo) {
     pthread_kill(pthread_self(), signo);
 }
 
-static void sigsegv_action() noexcept {
+static void sigsegv_action(siginfo_t *info, ucontext_t* uc) noexcept {
+    print_safe("Segmentation fault: si_code: ");
+    auto code = info->si_code;
+    print_decimal_safe(static_cast<unsigned>(info->si_code));
+
+    if (code == SI_USER) {
+        print_safe(", si_pid: ");
+        // print the pid in the case the signal was sent by someone else
+        print_decimal_safe(static_cast<unsigned>(info->si_pid));
+    } else if (code == SEGV_MAPERR || code == SEGV_MAPERR || code == SEGV_BNDERR) {
+        // print the address of the data access
+        print_safe(", si_addr: ");
+        print_zero_padded_hex_safe(reinterpret_cast<uintptr_t>(info->si_addr));
+    }
+
+
+    uintptr_t ip;
+    if (uc) {
+#if defined(__x86_64__)
+        ip = uc->uc_mcontext.gregs[REG_RIP];
+#elif defined(__aarch64__)
+        ip = uc->uc_mcontext.pc;
+#else
+        ip = 0xBAD;
+#endif
+    } else {
+        ip = 0xBAD2;
+    }
+    print_safe(", ip: ");
+    print_zero_padded_hex_safe(ip);
+    print_safe("\n");
+
+    // Print the resolved IP, i.e., suitable for use
+    // with addr2line and other tools which expect an
+    // address without any added offset (from ASLR or
+    // because it's a relocated shared object).
+    print_safe("Segmentation fault: resolved ip: ");
+    auto f = decorate(ip);
+    print_zero_padded_hex_safe(f.addr);
+    print_safe(" in ");
+    print_safe(f.so->name.c_str());
+    print_safe("[");
+    print_zero_padded_hex_safe(f.so->begin);
+    print_safe("+");
+    print_zero_padded_hex_safe(f.so->end - f.so->begin);
+    print_safe("]\n");
+
     print_with_backtrace("Segmentation fault");
     reraise_signal(SIGSEGV);
 }
 
-static void sigabrt_action() noexcept {
+static void sigabrt_action(siginfo_t *info, ucontext_t* uc) noexcept {
     print_with_backtrace("Aborting");
     reraise_signal(SIGABRT);
 }

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4146,14 +4146,14 @@ static void sigsegv_action(siginfo_t *info, ucontext_t* uc) noexcept {
     // with addr2line and other tools which expect an
     // address without any added offset (from ASLR or
     // because it's a relocated shared object).
-    print_safe("Segmentation fault: resolved ip: ");
+    print_safe("Segmentation fault: resolved ip: 0x");
     auto f = decorate(ip);
     print_zero_padded_hex_safe(f.addr);
     print_safe(" in ");
     print_safe(f.so->name.c_str());
-    print_safe("[");
+    print_safe("[0x");
     print_zero_padded_hex_safe(f.so->begin);
-    print_safe("+");
+    print_safe("+0x");
     print_zero_padded_hex_safe(f.so->end - f.so->begin);
     print_safe("]\n");
 

--- a/tests/unit/stall_detector_test.cc
+++ b/tests/unit/stall_detector_test.cc
@@ -88,6 +88,58 @@ SEASTAR_THREAD_TEST_CASE(spin_in_kernel) {
     test_spin_with_body("kernel", [] { mmap_populate(128 * 1024); });
 }
 
+// This test reproduces the issue described in https://github.com/scylladb/seastar/issues/2697
+// The issue is reproduced most quickly using the following arguments:
+// --blocked-reactor-notify-ms=1
+// but it will happen with default arguments as well.
+SEASTAR_THREAD_TEST_CASE(stall_detector_crash) {
+    // increase total_iters to increase chance of failure
+    // the value below is tuned to take about 1 second in
+    // release builds
+    constexpr auto total_iters = 100000;
+    constexpr int max_depth = 20;
+
+    auto now = [] { return std::chrono::high_resolution_clock::now(); };
+
+    auto recursive_thrower = [](auto self, int x) -> void {
+        if (x <= 0) {
+            throw std::runtime_error("foo");
+        } else {
+            try {
+                self(self, x - 1);
+            } catch (...) {
+                if (x & 0xF) {
+                    throw;
+                }
+            }
+        }
+    };
+
+    auto next_yield = now();
+    for (int a = 1; a < total_iters; a++) {
+        if (now() > next_yield) {
+            // we need to periodically yield or else the stall reports will become
+            // less and less frequent as exponentially grow the report interval while
+            // the same task is running
+            thread::yield();
+            next_yield = now() + 40ms;
+            // the next line resets the suppression state which allows many more reports
+            // per second, increasing the chance of a failure
+            reactor::test::set_stall_detector_report_function({});
+        }
+
+        try {
+            recursive_thrower(recursive_thrower, a % max_depth);
+        } catch (...) {
+        }
+
+        if (a % 100000 == 0) {
+            fmt::print("Making progress: {:6.3f}%\n", 100. * a / total_iters);
+        }
+  }
+}
+
+
 
 #else
 


### PR DESCRIPTION
This downstreams most of the updates and fixes related to CORE-9596:

Diagnostic upgrades (accepted upstream):
https://github.com/scylladb/seastar/pull/2691
https://github.com/scylladb/seastar/pull/2727

Crash fix (not accepted upstream yet):
https://github.com/scylladb/seastar/pull/2714

I did not downstream one diagnostic fix (accepted upstream) because it does not merge cleanly due to earlier changes to the stall notifier which are not yet in our fork:

https://github.com/scylladb/seastar/pull/2712

We will get this fix when we rebase on steastar master.

I plan to backport these to at least 24.2.