### PR TITLE
[v24.3.x] tls/ossl: Improved handling of OpenSSL error conditions

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -939,13 +939,29 @@ public:
         switch(ssl_err) {
         case SSL_ERROR_ZERO_RETURN:
             // Indicates a hang up somewhere
-            // Mark _eof and stop iteratio
+            // Mark _eof, ensure any output pending items complete,
+            // and stop iteration
             _eof = true;
-            return make_ready_future<stop_iteration>(stop_iteration::yes);
+            return wait_for_output().then([] {
+                return stop_iteration::yes;
+            });
+        case SSL_ERROR_WANT_READ:
+            // Wait for any outstanding writes to complete and then
+            // wait for input data to be available
+            return wait_for_output().then([this] {
+                return wait_for_input().then([] {
+                    return stop_iteration::no;
+                });
+            });
         case SSL_ERROR_NONE:
             // Should not have been reached in this situation
             // Continue iteration
-            return make_ready_future<stop_iteration>(stop_iteration::no);
+            // Fallthrough as NONE and WANT_WRITE are handled the same
+            [[fallthrough]];
+        case SSL_ERROR_WANT_WRITE:
+            return wait_for_output().then([] {
+                return stop_iteration::no;
+            });
         case SSL_ERROR_SYSCALL:
         {
             auto err = make_ossl_error("System error encountered during SSL write");
@@ -956,7 +972,7 @@ public:
         case SSL_ERROR_SSL: {
             auto error_codes = get_all_ossl_errors();
             if (contains_ossl_error(error_codes, ERR_LIB_SSL, SSL_R_UNEXPECTED_EOF_WHILE_READING)) {
-                // Probably shouldn't have during a write, but
+                // Probably shouldn't happen during a write, but
                 // let's handle this gracefully
                 _eof = true;
                 return make_ready_future<stop_iteration>(stop_iteration::yes);
@@ -983,16 +999,13 @@ public:
     // This function takes and holds the sempahore units for _out_sem and
     // will attempt to send the provided packet.  If a renegotiation is needed
     // any unprocessed part of the packet is returned.
-    future<net::packet> do_put(net::packet p) {
-        if (!connected()) {
-            return make_ready_future<net::packet>(std::move(p));
-        }
+    future<> do_put(net::packet p) {
         assert(_output_pending.available());
         return do_with(std::move(p),
             [this](net::packet& p) {
                 // This do_until runs until either a renegotiation occurs or the packet is empty
                 return do_until(
-                    [this, &p] { return eof() || !connected() || p.len() == 0;},
+                    [this, &p] { return eof() || p.len() == 0;},
                     [this, &p]() mutable {
                         std::string_view frag_view =
                             {p.fragments().begin()->base, p.fragments().begin()->size};
@@ -1005,14 +1018,6 @@ public:
                                 _ssl.get(), frag_view.data(), frag_view.size(), &bytes_written);
                             if (write_rc != 1) {
                                 const auto ssl_err = SSL_get_error(_ssl.get(), write_rc);
-                                if (ssl_err == SSL_ERROR_WANT_WRITE) {
-                                    return wait_for_output().then([] {
-                                        return stop_iteration::no;
-                                    });
-                                } else if (!connected() || ssl_err == SSL_ERROR_WANT_READ) {
-                                    ERR_clear_error();
-                                    return make_ready_future<stop_iteration>(stop_iteration::yes);
-                                }
                                 return handle_do_put_ssl_err(ssl_err);
                             } else {
                                 frag_view.remove_prefix(bytes_written);
@@ -1023,9 +1028,7 @@ public:
                             }
                         });
                     }
-                ).then([&p] {
-                    return std::move(p);
-                });
+                );
             }
         );
     }
@@ -1057,14 +1060,6 @@ public:
         }
         return with_semaphore(_out_sem, 1, [this, p = std::move(p)]() mutable {
             return do_put(std::move(p));
-        }).then([this](net::packet p) {
-            if (eof() || p.len() == 0) {
-                return make_ready_future();
-            } else {
-                return handshake().then([this, p = std::move(p)]() mutable {
-                    return put(std::move(p));
-                });
-            }
         });
     }
 
@@ -1202,11 +1197,16 @@ public:
                     // well we shouldn't be here at all
                     return make_ready_future<buf_type>();
                 case SSL_ERROR_WANT_WRITE:
+                    // OpenSSL needs to send data over the wire before it can read
                     return wait_for_output().then([this] { return do_get(); });
                 case SSL_ERROR_WANT_READ:
-                    // This may be caused by a renegotiation request, in this situation
-                    // return an empty buffer (the get() function will initiate a handshake)
-                    return make_ready_future<buf_type>();
+                    // OpenSSL needs to read data off of the write to process
+                    // SSL_read.  Send any data waiting to go out and then wait for input
+                    return wait_for_output().then([this] {
+                        return wait_for_input().then([this] {
+                            return do_get();
+                        });
+                    });
                 case SSL_ERROR_SYSCALL:
                     if (ERR_peek_error() == 0) {
                         // SSL_get_error
@@ -1259,15 +1259,11 @@ public:
             return make_ready_future<buf_type>(buf_type());
         }
         if (!connected()) {
-            return handshake().then(std::bind(&session::get, this));
+            return handshake().then([this] { return get(); });
         }
-        return with_semaphore(_in_sem, 1, std::bind(&session::do_get, this))
-          .then([this](buf_type buf) {
-              if (buf.empty() && !eof()) {
-                  return handshake().then(std::bind(&session::get, this));
-              }
-              return make_ready_future<buf_type>(std::move(buf));
-          });
+        return with_semaphore(_in_sem, 1, [this] {
+            return do_get();
+        });
     }
 
     // Performs shutdown
@@ -1427,9 +1423,11 @@ public:
         // before us will get it instead of us, and mark _eof = true
         // in which case we will be no-op. This is performed all
         // within do_shutdown
-        return with_semaphore(_out_sem, 1,
-                              std::bind(&session::do_shutdown, this)).then(
-                              std::bind(&session::wait_for_eof, this)).finally([me = shared_from_this()] {});
+        return with_semaphore(_out_sem, 1, [this] {
+                                return do_shutdown();
+                              }).then([this] {
+                                return wait_for_eof();
+                              }).finally([me = shared_from_this()]{});
         // note moved finally clause above. It is theorethically possible
         // that we could complete do_shutdown just before the close calls
         // below, get pre-empted, have "close()" finish, get freed, and


### PR DESCRIPTION
NOTE: Backport of https://github.com/redpanda-data/seastar/pull/215

Prior to this commit, in certain situations, the put() and get() methods would 'drop into' handshake() if they determined that a re-negotiation was occurring.  This was unecessary as OpenSSL provides helpful error codes like SSL_WANT_READ and SSL_WANT_WRITE which indicates if OpenSSL needed to send/receive non-user data to handle re-negotiations.

This may have also led to a rare situation where the put() method would assert because the _output_pending future had not resolved.  This change properly handles the SSL_WANT_READ and SSL_WANT_WRITE conditions and ensures that the _output_pending future resolves.


(cherry picked from commit 604293e28b301221fe16f648cb61a8f3aa77af0b) (cherry picked from commit 06eb9827bbeb8572ffc3708411f08f13e03295fb)