### PR TITLE
addr2line timing and optimizations (RP version)

### DIFF
--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -268,7 +268,7 @@ class BacktraceResolver:
                 addresses.append({'path': m.group(1) or default_path, 'addr': m.group(2)})
             return addresses
 
-        def __call__(self, line: str):
+        def __call__(self, line: str) -> dict[str, Any] | None:
 
             def get_prefix(s: Optional[str]):
                 if s is not None:

--- a/scripts/addr2line.py
+++ b/scripts/addr2line.py
@@ -25,6 +25,7 @@ import sys
 import subprocess
 from enum import Enum
 from functools import cache
+import time
 from typing import Any, Optional, TypeVar, Union, cast
 
 # special binary path/module indicating that the address is from the kernel
@@ -352,8 +353,11 @@ class BacktraceResolver:
         concise: bool = False,
         cmd_path: str = 'addr2line',
         debug: bool = False,
+        timing: bool = False,
     ):
         self._debug = debug
+        self._timing = timing
+        self._total_resolve_time = 0.0
         self._executable = executable
         self._kallsyms = kallsyms
         self._current_backtrace: list[tuple[str, str]] = []
@@ -379,6 +383,19 @@ class BacktraceResolver:
         if self._debug:
             print('DEBUG >>', *args, file=sys.stderr)
 
+    def timing_now(self):
+        return time.perf_counter() if self._timing else 0.0
+
+    def timing_print_from_start(self, start: float, *args: Any):
+        self.timing_print(self.timing_now() - start, *args)
+
+    def timing_print(self, duration: float, *args: Any):
+        if self._timing:
+            print(f"TIMING >> {duration:.4f} seconds : ", *args, file=sys.stderr)
+
+    def print_resolve_time(self):
+        self.timing_print(self._total_resolve_time, 'resolve time (addr2line subprocess time)')
+
     def _get_resolver_for_module(self, module: str):
         if not module in self._known_modules:
             if module == KERNEL_MODULE:
@@ -403,7 +420,10 @@ class BacktraceResolver:
             module = self._executable
         if verbose is None:
             verbose = self._verbose
-        resolved_address = self._get_resolver_for_module(module)(address)
+        resolver = self._get_resolver_for_module(module)
+        resolve_start = self.timing_now()
+        resolved_address = resolver(address)
+        self._total_resolve_time += self.timing_now() - resolve_start
         if verbose:
             resolved_address = '{{{}}} {}: {}'.format(module, address, resolved_address)
         return resolved_address

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -496,7 +496,7 @@ There are three operational modes:
         lines = args.addresses
     else:
         if sys.stdin.isatty():
-            lines = read_backtrace(sys.stdin)
+            lines = list(read_backtrace(sys.stdin))
         else:
             lines = sys.stdin
 
@@ -509,7 +509,7 @@ There are three operational modes:
         cmd_path=args.addr2line,
         debug=args.debug,
     ) as resolve:
-        for line in list(lines):
+        for line in lines:
             resolve(line.strip() + '\n')
 
 

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -469,6 +469,10 @@ There are three operational modes:
     )
 
     cmdline_parser.add_argument(
+        '--timing', action='store_true', help='Emit timing information to stderr.'
+    )
+
+    cmdline_parser.add_argument(
         '-t', '--test', action='store_true', default=False, help='Self-test'
     )
 
@@ -508,9 +512,13 @@ There are three operational modes:
         verbose=args.verbose,
         cmd_path=args.addr2line,
         debug=args.debug,
+        timing=args.timing,
     ) as resolve:
+        resolve_start = resolve.timing_now()
         for line in lines:
             resolve(line.strip() + '\n')
+        resolve.timing_print_from_start(resolve_start, 'full resolve loop')
+        resolve.print_resolve_time()
 
 
 if __name__ == '__main__':

--- a/scripts/seastar-addr2line
+++ b/scripts/seastar-addr2line
@@ -72,7 +72,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_addresses_only(self):
-        data = [
+        data: TestList = [
             (
                 '0x12f34',
                 {
@@ -123,7 +123,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_without_prefix(self):
-        data = [
+        data: TestList = [
             (
                 'Some prefix 0x12f34',
                 {
@@ -144,7 +144,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_reactor_stall_reports(self):
-        data = [
+        data: TestList = [
             (
                 'Reactor stalled on shard 1. Backtrace: 0x12f34',
                 {
@@ -189,7 +189,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_boost_failure(self):
-        data = [
+        data: TestList = [
             (
                 'Expected partition_end(), but got end of stream, at 0xa1234 0xb5678 /my/path+0xabcd',
                 {
@@ -206,7 +206,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_asan_failure(self):
-        data = [
+        data: TestList = [
             (
                 '==16118==ERROR: AddressSanitizer: heap-use-after-free on address 0x60700019c710 at pc 0x000014d24643 bp 0x7ffc51f72220 sp 0x7ffc51f72218',
                 None,
@@ -242,7 +242,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_thrown_exception(self):
-        data = [
+        data: TestList = [
             (
                 'seastar::internal::backtraced<std::runtime_error> (throw_with_backtrace_exception_logging Backtrace: 0x42bc95 /lib64/libc.so.6+0x281e1 0x412cfd)',
                 {
@@ -285,7 +285,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_assertion_failure(self):
-        data = [
+        data: TestList = [
             (
                 "2022-04-15T06:19:24+00:00 gemini-1tb-10h-master-db-node-c0c7fc43-4 !    INFO | "
                 "scylla: sstables/consumer.hh:610: future<> data_consumer::continuous_data_consumer"
@@ -322,7 +322,7 @@ class TestStringMethods(unittest.TestCase):
         self._test(data)
 
     def test_segfault_failure(self):
-        data = [
+        data: TestList = [
             ('[2022-04-19T23:09:28.311Z] Segmentation fault on shard 1.', None),
             ('[2022-04-19T23:09:28.311Z] Backtrace:', None),
             (


### PR DESCRIPTION
We sometimes parse large logfiles thorugh addr2line and noted that it can be quite slow and consume a large amount of memory. E.g., 3-15 minutes (the high end on memory constrained host) and 2.1 GB RSS in order to parse a 1.6 GB file.

The changes here improve that to 100 MB (probably almost all in the child addr2line process) and ~7s parsing time (split 6/1 in the Python code and addr2line itself).

Key perf changes are to not load the entire file into a `list` up front and to do a quick filter on each line to see if we should even bother applying the regexes. Details in individual commits.


This pull request introduces performance improvements and new timing features in the `addr2line` script, along with updates to its corresponding test suite. The main changes include adding timing functionality for debugging performance, optimizing regex matching, and enhancing test type annotations for clarity.

### Performance and Timing Enhancements:

* Added timing functionality to measure and log the duration of operations in the `addr2line` script. This includes new methods (`timing_now`, `timing_print_from_start`, `timing_print`, and `print_resolve_time`) and a `timing` flag in the class constructor to enable or disable timing logs. (`scripts/addr2line.py`, [[1]](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8R356-R360) [[2]](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8R386-R398)
* Optimized address resolution by introducing a quick upfront check to filter lines without addresses, significantly reducing regex matching overhead. (`scripts/addr2line.py`, [scripts/addr2line.pyL271-R281](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8L271-R281))
* Enhanced timing support in the command-line interface by adding a `--timing` argument to emit timing information during script execution. (`scripts/seastar-addr2line`, [[1]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caR471-R474) [[2]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caR515-R521)

### Code Quality Improvements:

* Updated type annotations for test data in the `seastar-addr2line` test suite, replacing generic lists with `TestList` for improved clarity and maintainability. (`scripts/seastar-addr2line`, [[1]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL75-R75) [[2]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL126-R126) [[3]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL147-R147) [[4]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL192-R192) [[5]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL209-R209) [[6]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL245-R245) [[7]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL288-R288) [[8]](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL325-R325)

### Minor Adjustments:

* Imported the `time` module in `addr2line.py` to support the new timing functionality. (`scripts/addr2line.py`, [scripts/addr2line.pyR28](diffhunk://#diff-cd6a2af470efe68703f2ffd367c7b7e260f28ced194949fb1571a53d7d5f4ab8R28))
* Modified input handling in `seastar-addr2line` to convert stdin backtrace lines into a list for compatibility with the updated resolve loop. (`scripts/seastar-addr2line`, [scripts/seastar-addr2lineL499-R503](diffhunk://#diff-daf58e1efe76abbb947170e8009efedaf9fd1e27443351a6636c062a1a98c2caL499-R503))