### PR TITLE
various Alpine fixes

### DIFF
--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -54,6 +54,7 @@ jobs:
       run: |
         cmake -B build -G Ninja            \
          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+         -DSeastar_WITH_OSSL=yes           \
          -DSeastar_DOCS=OFF
 
     - name: Build Seastar

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1155,7 +1155,10 @@ posix_timer::posix_timer(timer_cfg cfg, clockid_t clock_id) {
     struct sigevent sev = {};
     sev.sigev_notify = SIGEV_THREAD_ID;
     sev.sigev_signo = cfg.signal_number;
-    sev._sigev_un._tid = syscall(SYS_gettid);
+#ifndef sigev_notify_thread_id
+#define sigev_notify_thread_id _sigev_un._tid
+#endif
+    sev.sigev_notify_thread_id = syscall(SYS_gettid);
     int err = timer_create(clock_id, &sev, &_timer);
     if (err) {
         throw std::system_error(std::error_code(err, std::system_category()));

--- a/tests/unit/cpu_profiler_test.cc
+++ b/tests/unit/cpu_profiler_test.cc
@@ -32,6 +32,7 @@
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/backtrace.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/later.hh>
 
@@ -40,6 +41,15 @@
 #include <sys/mman.h>
 
 #include <boost/test/tools/old/interface.hpp>
+
+#ifdef SEASTAR_BACKTRACE_UNIMPLEMENTED
+
+// If backtrace is not implemented, we cannot test the profiler.
+// empty test case to satisfy the requirement that there is at least one test case
+SEASTAR_THREAD_TEST_CASE(simple_case) {
+}
+
+#else
 
 namespace {
 
@@ -377,3 +387,5 @@ SEASTAR_THREAD_TEST_CASE(scheduling_group_test) {
     BOOST_CHECK_LT(count_main, 10);
     BOOST_CHECK_LT(dropped_samples, 5);
 }
+
+#endif

--- a/tests/unit/stall_detector_test_utilities.hh
+++ b/tests/unit/stall_detector_test_utilities.hh
@@ -131,7 +131,7 @@ inline void test_spin_with_body(const char* what, void_fn body) {
     }
 }
 
-void mmap_populate(size_t len) {
+inline void mmap_populate(size_t len) {
     void *p = mmap(nullptr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, 0, 0);
     BOOST_REQUIRE(p != MAP_FAILED);
     BOOST_REQUIRE(munmap(p, len) == 0);


### PR DESCRIPTION
guarded_backtrace has a static local mutex but was in an anonymous namespace, which is unsafe as each translation unit would have its own instance.

Move it to the .cc file (it's happier there anyway) and remove the anonymous namespace.

Also fix the alpine build by only building this is execinfo is available.