### PR TITLE
SEASTAR_ASSERT: assert to stderr and flush stream

### DIFF
--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -124,7 +124,8 @@ namespace seastar {
 namespace internal {
 
 [[noreturn]] void assert_fail(const char* msg, const char* file, int line, const char* func) {
-    printf("%s:%u: %s: Assertion `%s` failed.\n", file, line, func, msg);
+    fprintf(stderr, "%s:%u: %s: Assertion `%s` failed.\n", file, line, func, msg);
+    std::fflush(stderr);
     std::terminate();
 }
 


### PR DESCRIPTION
We notice that assertion messages are not being printed as expected.

In these cases you simply see a message like (libc++):

```
libc++abi: terminating
Aborting on shard 0, in scheduling group main.
Backtrace:
```

libstd++ is similar:

```
terminate called without an active exception
Aborting on shard 0, in scheduling group main.
Backtrace:
```

Underlying cause is that we print to stdout, and stdout is not explicitly flushed. In cases where stdout is not line buffered, we will close the message (so e.g., when the output is piped or redirected).

We should (a) assert to stderr, not stdout, and (b) flush the stream.

This is in line with libc and the C++ standard (though it specifies that abort() is called, not std::terminate()).

(cherry picked from commit 8b46e3d4aa769164e6ac6523aeb69209fbc2a6ef)