### PR TITLE
net/tls: verify peer name in OpenSSL client sessions

### DIFF
--- a/src/net/tls_openssl.cc
+++ b/src/net/tls_openssl.cc
@@ -895,6 +895,29 @@ public:
             if (!_options.server_name.empty()) {
                 SSL_set_tlsext_host_name(
                   _ssl.get(), _options.server_name.c_str());
+                if (_creds->_enable_certificate_verification) {
+                    // OpenSSL matches the peer certificate against the name
+                    // we intended to connect to only when that name is
+                    // installed as a reference identifier on the
+                    // verification parameters; chain validation alone
+                    // accepts a certificate issued to anyone, as long as
+                    // the issuer is trusted. A mismatch is reported through
+                    // SSL_get_verify_result(), which verify() converts into
+                    // a verification_error. Matching GnuTLS semantics: an
+                    // IP literal is matched against iPAddress SANs, a DNS
+                    // name against dNSName SANs (subject CN as fallback),
+                    // and partial-wildcard matching is disabled.
+                    auto* param = SSL_get0_param(_ssl.get());
+                    X509_VERIFY_PARAM_set_hostflags(
+                      param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+                    const auto& name = _options.server_name;
+                    if (1 != X509_VERIFY_PARAM_set1_ip_asc(param, name.c_str())
+                        && 1 != X509_VERIFY_PARAM_set1_host(
+                          param, name.c_str(), name.size())) {
+                        throw make_openssl_error(
+                          "Failed to set expected server name");
+                    }
+                }
             }
             SSL_set_connect_state(_ssl.get());
         }

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -782,8 +782,33 @@ SEASTAR_TEST_CASE(test_x509_client_server_cert_validation_fail) {
 }
 
 SEASTAR_TEST_CASE(test_x509_client_server_cert_validation_fail_name) {
-    // Use trust store with our signer, but wrong host name
-    return run_echo_test(message, 1, certfile("tls-ca-bundle.pem"), "nils.holgersson.gov").then([] {
+    // Use trust store with our signer, but wrong host name. The certificate
+    // chain is fully trusted, so the only thing standing between the client
+    // and an impostor is the peer name check.
+    return run_echo_test(message, 1, certfile("catest.pem"), "nils.holgersson.gov").then([] {
+            BOOST_FAIL("Should have gotten validation error");
+    }).handle_exception([](auto ep) {
+        try {
+            std::rethrow_exception(ep);
+        } catch (tls::verification_error&) {
+            // ok.
+        } catch (...) {
+            BOOST_FAIL("Unexpected exception");
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_x509_client_server_cert_validation_ip_match) {
+    // test.crt carries an iPAddress SAN for 127.0.0.1. An IP-literal
+    // server_name must be matched against that SAN as an address, not as a
+    // DNS name.
+    return run_echo_test(message, 1, certfile("catest.pem"), "127.0.0.1");
+}
+
+SEASTAR_TEST_CASE(test_x509_client_server_cert_validation_fail_ip) {
+    // Trusted signer, but an IP that does not match the certificate's
+    // iPAddress SAN (127.0.0.1).
+    return run_echo_test(message, 1, certfile("catest.pem"), "127.0.0.2").then([] {
             BOOST_FAIL("Should have gotten validation error");
     }).handle_exception([](auto ep) {
         try {


### PR DESCRIPTION
## Problem

The OpenSSL backend uses `tls_options::server_name` only as the SNI extension value, and certificate verification stops at chain validation. A client session therefore accepts **any certificate that chains to a trusted root, for any peer** — any holder of a trusted-issuer certificate can impersonate any server. The GnuTLS backend has always passed `server_name` to `gnutls_certificate_verify_peers3()`, which also matches the peer certificate against that name, so switching providers silently drops server authentication with no error, warning, or log line.

The existing negative test (`test_x509_client_server_cert_validation_fail_name`) did not catch this because it loads `tls-ca-bundle.pem` as the trust store, which does not sign `test.crt` — it fails on chain validation regardless of the name, on both backends.

## Fix

Install the requested name as a reference identifier on the client session's `X509_VERIFY_PARAM`, so the existing `SSL_VERIFY_PEER` machinery performs the name check as part of chain verification. A mismatch fails the handshake and surfaces through `SSL_get_verify_result()` as `X509_V_ERR_HOSTNAME_MISMATCH` (62) or `X509_V_ERR_IP_ADDRESS_MISMATCH` (64), which `verify()` already converts into the same `tls::verification_error` the GnuTLS backend throws. No new error plumbing.

Semantics match GnuTLS:

- client sessions only; server-side handling of client certificates is unchanged (neither backend has ever name-checked those)
- skipped when certificate verification is disabled on the credentials (`certificate_credentials::set_enable_certificate_verification(false)`)
- an IP-literal name is matched against iPAddress SANs, a DNS name against dNSName SANs (subject CN fallback). OpenSSL 3.0's `SSL_set1_host()` does not recognize IP literals, so the name is installed with `X509_VERIFY_PARAM_set1_ip_asc()` first, falling back to `X509_VERIFY_PARAM_set1_host()`
- partial-wildcard matching (`w*.example.com`) is disabled via `X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS`

The `server_name` doc comment in `tls.hh` now describes the name check alongside SNI.

## Tests

- `test_x509_client_server_cert_validation_fail_name` now trusts `catest.pem` (per its own comment), so the name check is the only thing it exercises
- new `test_x509_client_server_cert_validation_ip_match`: `server_name = "127.0.0.1"` succeeds via `test.crt`'s `IP:127.0.0.1` SAN — guards against the name check breaking IP-addressed endpoints
- new `test_x509_client_server_cert_validation_fail_ip`: `server_name = "127.0.0.2"` is rejected

## Verification

Dual-backend dev build (`--tls-mode=both`), same binary, same certs:

| run | gnutls | openssl |
| --- | --- | --- |
| new/fixed tests, backend unfixed | pass | **`fail_name` and `fail_ip` fail** — client completes TLS and exchanges data with a peer presenting a certificate for a different name/IP |
| new/fixed tests, backend fixed | pass | pass |
| full `tls_test` suite, backend fixed | No errors detected | No errors detected |

The full-suite runs confirm no regression: all positive `test.scylladb.org` connections, session resumption, cert reload, and mTLS tests pass with the name check active.

Out of scope, kept for follow-ups: both backends still send IP literals in SNI (RFC 6066 forbids this; interop wart, not a security issue), and there is no separate "verify name" option distinct from SNI for proxy/CNAME topologies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

