### PR TITLE
build: fix the heap profiling build and cover it in CI

### DIFF
--- a/.github/workflows/install-build-env.sh
+++ b/.github/workflows/install-build-env.sh
@@ -109,6 +109,7 @@ group "configure.py"
     --compiler "$CPP"           \
     --c-compiler "$CC"          \
     --mode "$MODE"              \
+    --heap-profiling            \
     "${cook_args[@]}"           \
     "${ccache_opt[@]}"          \
     $OPTIONS                    \

--- a/include/seastar/core/chunked_hash_map.hh
+++ b/include/seastar/core/chunked_hash_map.hh
@@ -22,7 +22,23 @@
 
 #include <seastar/core/chunked_vector.hh>
 
+// abseil LTS 20220623 and earlier include <ciso646> from
+// absl/base/options.h. libstdc++ 16 warns on that header for C++20 and later,
+// and seastar builds with -Werror.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-W#warnings"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcpp"
+#endif
 #include <absl/hash/hash.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <ankerl/unordered_dense.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -591,7 +591,15 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
         BOOST_REQUIRE_EQUAL(stats.size(), 0);
     }
 
-    std::size_t count = 100;
+    // The two loops below are distinct call sites and the assertions require
+    // both of them to be sampled, so each loop has to cover enough sampling
+    // intervals that missing one entirely is not plausible. The sampler draws
+    // the gap to the next sample from an exponential distribution whose mean is
+    // the sampling interval, so a loop allocating N intervals worth of bytes
+    // records nothing with probability e^-N. count/2 * 10 bytes against the 100
+    // byte interval below is N=50, putting the chance of recording one call
+    // site instead of two at about 2*e^-50.
+    std::size_t count = 1000;
     std::vector<volatile char*> ptrs(count);
 
     seastar::memory::set_heap_profiling_sampling_rate(100);
@@ -668,7 +676,16 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     std::size_t count = 100;
     std::vector<volatile char*> ptrs(count);
 
-    seastar::memory::set_heap_profiling_sampling_rate(1000000);
+    // Both loops have to be sampled, as in
+    // test_sampled_profile_collection_small: count/2 * 100000 bytes against
+    // this interval is N=25 intervals per loop, so the chance of recording one
+    // call site instead of two is about 2*e^-25. The interval also has to stay
+    // above the 131072 bytes that a 100000 byte request actually allocates, so
+    // that sample_size() accounts each sample as one full interval and the
+    // size == count * sample_rate check below holds.
+    std::size_t sample_rate = 200000;
+
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
 
 #ifdef __clang__
     #pragma nounroll
@@ -690,10 +707,10 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_large)
     {
         auto stats = seastar::memory::sampled_memory_profile();
         BOOST_REQUIRE_EQUAL(stats.size(), 2);
-        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * 1000000);
+        BOOST_REQUIRE_EQUAL(stats[0].size, stats[0].count * sample_rate);
     }
 
-    seastar::memory::set_heap_profiling_sampling_rate(1000000);
+    seastar::memory::set_heap_profiling_sampling_rate(sample_rate);
 
     for (auto ptr : ptrs) {
         free((void*)ptr);

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -615,20 +615,20 @@ SEASTAR_TEST_CASE(test_sampled_profile_collection_small)
         auto stats1 = seastar::memory::sampled_memory_profile();
 
         // two back-to-back copies of the sample should have the same value
-        BOOST_CHECK_EQUAL(stats0, stats1);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats1.begin(), stats1.end());
 
         // check that we get the same value from the raw array iterface
         std::vector<seastar::memory::allocation_site> stats2(stats0.size());
         auto sz2 = seastar::memory::sampled_memory_profile(stats2.data(), stats2.size());
         BOOST_CHECK_EQUAL(stats0.size(), sz2);
-        BOOST_CHECK_EQUAL(stats0, stats2);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats2.begin(), stats2.end());
 
         // check with +1 size, we expect to still only get size elements
         std::vector<seastar::memory::allocation_site> stats3(stats0.size() + 1);
         auto sz3 = seastar::memory::sampled_memory_profile(stats3.data(), stats3.size());
         BOOST_CHECK_EQUAL(stats0.size(), sz3);
         stats3.resize(sz3);
-        BOOST_CHECK_EQUAL(stats0, stats3);
+        BOOST_CHECK_EQUAL_COLLECTIONS(stats0.begin(), stats0.end(), stats3.begin(), stats3.end());
 
         return stats0;
     };


### PR DESCRIPTION
A few build/test fixes. Downstream one build fix and one test fix,
add one additional build fix to our fork, and enable --heap-profiling
in CI.

- tests/alloc_test: compare sample vectors with EQUAL_COLLECTIONS
- core/chunked_hash_map: silence the absl <ciso646> warning
- tests/alloc: give the sampled profile tests a real sampling margin
- ci: build every job with --heap-profiling

No prod code changes.

<details><summary>.</summary>

A heap profiling build of seastar did not compile. There were two independent
breaks, and CI saw neither of them, because `--heap-profiling` is off by
default and no job passed it. Redpanda builds seastar with heap profiling, so
the breaks reached developers and redpanda while CI stayed green.

The first break is in `alloc_test`: the sampled profile tests compared
`std::vector<allocation_site>` with `BOOST_CHECK_EQUAL`, which needs an
`operator<<` for the vector itself, and nothing provides one. The second is the
`<ciso646>` warning reached through the abseil include in
`chunked_hash_map.hh`: abseil LTS 20220623, which Ubuntu 24.04 ships, includes
`<ciso646>` unconditionally from `absl/base/options.h`, libstdc++ 16 warns on
that header for C++20 and later, and seastar builds with `-Werror`.

Commits 1 and 3 are backports of commits already in scylladb/master, so they
carry cherry-pick trailers. Commit 2 has no upstream counterpart:
`chunked_hash_map.hh` is fork-only. Commit 4 closes the coverage gap that let
both breaks through in the first place.

Two notes on the fixes. The abseil suppression is scoped to the one include
rather than a build-wide `-Wno-error=#warnings`, and `chunked_hash_map.hh` is
the only file in the tree that includes abseil. Dropping abseil in favour of
unordered_dense alone was considered and rejected: the default hash
deliberately dispatches to `absl::Hash` for keys that define `AbslHashValue`,
so removing it would change which hash those keys get. And commit 3 is a
prerequisite for commit 4, not an optional extra: the sampled profile tests sit
behind `#ifdef SEASTAR_HEAPPROF`, so commit 4 is what makes them run at all,
and at their previous sizing they failed on about 1.3% of runs.

`--heap-profiling` goes into the shared `configure.py` call in
`install-build-env.sh` rather than into a matrix entry, so every job builds
with it. It has no effect where the default allocator is in use, such as the
sanitize jobs.

Testing: a full `ninja` build of a `--heap-profiling` `build/dev` goes from two
hard failures to clean, and `chunked_hash_map_test` and `alloc_test` both pass,
with `alloc_test`'s log confirming the heap profiler engages. The abseil
suppression was checked against a standalone repro. The CI image was checked
too: `ubuntu:26.04` ships abseil 20260107, which takes the `<version>` branch
instead, and including `absl/hash/hash.h` there under `g++-16 -Wall -Werror` is
clean at both `-std=gnu++23` and `-std=gnu++26`, so CI never needed the
suppression.

Two follow-ups worth knowing. The suppression can go once the minimum abseil is
new enough to take the `<version>` branch; `cmake/SeastarDependencies.cmake`
currently asks for abseil with no version floor, so an alternative is to add
one and let configure fail with a clear message on older distros. And the
sampled profile tests have never run on GitHub runners: if the widened margin
still is not enough on noisier CPUs, that is where it will surface.

</details>
